### PR TITLE
fix: jobs 분리로 인한 zip 파일 생성 오류 해결

### DIFF
--- a/.github/workflows/dev_push.yml
+++ b/.github/workflows/dev_push.yml
@@ -1,4 +1,4 @@
-name: Dev branch Push Workflow (Test)
+name: Dev branch Push Workflow
 
 on:
   push:

--- a/.github/workflows/dev_push.yml
+++ b/.github/workflows/dev_push.yml
@@ -1,0 +1,45 @@
+name: Dev branch Push Workflow (Test)
+
+on:
+  push:
+    branches-ignore:
+      - main
+
+env:
+  PYTHON_VERSION: '3.10'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      # 1. 환경 설정
+      - name: Checkout source code
+        uses: actions/checkout@v3
+
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Setup Python venv
+        run: python -m venv venv
+
+      - name: Install dependencies
+        run: ./venv/bin/python -m pip install -r requirements.txt
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+#      # 2. 테스트 진행
+#      - name: Run tests with coverage
+#        run: ./venv/bin/python -m coverage run -m unittest discover -s tests -p "test_*.py"
+#        shell: bash
+#
+#      - name: Check test coverage
+#        id: coverage-check
+#        run: ./venv/bin/python -m coverage report -m
+#        shell: bash

--- a/.github/workflows/main_pr.yml
+++ b/.github/workflows/main_pr.yml
@@ -9,7 +9,7 @@ env:
   PYTHON_VERSION: '3.10'
 
 jobs:
-  setup:
+  test_and_comment:
     runs-on: ubuntu-latest
     steps:
       # 1. 환경 설정

--- a/.github/workflows/main_pr.yml
+++ b/.github/workflows/main_pr.yml
@@ -1,4 +1,4 @@
-name: Main branch PR Workflow (Test and Comment)
+name: Main branch PR Workflow
 
 on:
   pull_request:

--- a/.github/workflows/main_pr.yml
+++ b/.github/workflows/main_pr.yml
@@ -1,4 +1,4 @@
-name: Flask Test for PR
+name: Main branch PR Workflow (Test and Comment)
 
 on:
   pull_request:
@@ -9,12 +9,10 @@ env:
   PYTHON_VERSION: '3.10'
 
 jobs:
-  # 환경 설정 및 테스트 진행
   setup:
     runs-on: ubuntu-latest
-    outputs:
-      coverage: ${{ steps.coverage-check.outputs.coverage }}
     steps:
+      # 1. 환경 설정
       - name: Checkout source code
         uses: actions/checkout@v3
 
@@ -36,6 +34,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
+#      # 2. 테스트 진행
 #      - name: Run tests with coverage
 #        run: ./venv/bin/python -m coverage run -m unittest discover -s tests -p "test_*.py"
 #        shell: bash
@@ -43,21 +42,15 @@ jobs:
 #      - name: Check test coverage
 #        id: coverage-check
 #        run: |
-#          ./venv/bin/python -m coverage report -m
 #          COVERAGE=$(./venv/bin/python -m coverage report -m | grep TOTAL | awk '{print $6}' | sed 's/%//')
 #          echo "Test coverage: $COVERAGE%"
 #          echo "::set-output name=coverage::$COVERAGE"
 #        shell: bash
 #
-#  # PR일 경우, 테스트 커버리지를 PR Comment에 기록
-#  post-comment:
-#    needs: setup
-#    runs-on: ubuntu-latest
-#    if: github.event_name == 'pull_request'
-#    steps:
+#      # 3. 테스트 커버리지를 PR Comment에 기록
 #      - name: Post Test Coverage Report as PR Comment
 #        run: |
-#          COVERAGE=$(echo "${{ needs.setup.outputs.coverage }}" | awk '{print $1}')
+#          COVERAGE=${{ steps.coverage-check.outputs.coverage }}
 #          COMMENT="#### Test Coverage Report\n\`\`\`\nTest coverage: ${COVERAGE}%\n\`\`\`"
 #          echo $COMMENT | gh pr review ${{ github.event.pull_request.number }} --comment
 #        env:

--- a/.github/workflows/main_push.yml
+++ b/.github/workflows/main_push.yml
@@ -1,4 +1,4 @@
-name: Flask Test and Deploy to AWS for Push
+name: Main branch Push Workflow (Test and Deploy)
 
 on:
   push:
@@ -12,12 +12,10 @@ env:
   PYTHON_VERSION: '3.10'
 
 jobs:
-  # 환경 설정 및 테스트 진행
-  setup:
+  test_and_deploy:
     runs-on: ubuntu-latest
-    outputs:
-      coverage: ${{ steps.coverage-check.outputs.coverage }}
     steps:
+      # 1. 환경 설정
       - name: Checkout source code
         uses: actions/checkout@v3
 
@@ -39,6 +37,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
+#      # 2. 테스트 진행
 #      - name: Run tests with coverage
 #        run: ./venv/bin/python -m coverage run -m unittest discover -s tests -p "test_*.py"
 #        shell: bash
@@ -46,22 +45,16 @@ jobs:
 #      - name: Check test coverage
 #        id: coverage-check
 #        run: |
-#          ./venv/bin/python -m coverage report -m
 #          COVERAGE=$(./venv/bin/python -m coverage report -m | grep TOTAL | awk '{print $6}' | sed 's/%//')
 #          echo "Test coverage: $COVERAGE%"
 #          echo "::set-output name=coverage::$COVERAGE"
 #        shell: bash
-
-  # main에 대한 push일 경우, 테스트 커버리지가 60% 이상이면 배포 진행
-  deploy:
-    needs: setup
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    steps:
+#
+#      # 3. 배포 진행 (테스트 커버리지가 60% 이상일 경우)
 #      - name: Check Test Coverage Threshold
 #        id: check-coverage-threshold
 #        run: |
-#          COVERAGE=$(echo "${{ needs.setup.outputs.coverage }}" | awk '{print $1}')
+#          COVERAGE=${{ steps.coverage-check.outputs.coverage }}
 #          if (( $(echo "$COVERAGE < 60" | bc -l) )); then
 #            echo "테스트 커버리지가 부족하여 배포를 취소합니다."
 #            exit 1

--- a/.github/workflows/main_push.yml
+++ b/.github/workflows/main_push.yml
@@ -1,4 +1,4 @@
-name: Main branch Push Workflow (Test and Deploy)
+name: Main branch Push Workflow
 
 on:
   push:


### PR DESCRIPTION
- jobs 사이에 파일은 공유되지 않기 때문에 빌드된 파일을 가져오지 못해서 발생하는 문제로 파악
- artifact와 같은 기능을 이용할 수 있으나, 작업에 비해서 오버헤드가 크다고 판단하여 하나의 jobs로 합치는 대신, main push, main pr, other branch push 총 3개의 워크플로우로 분리