### PR TITLE
refactor: 환경 변수 호출 로직 정리

### DIFF
--- a/moview/environment/llm_factory.py
+++ b/moview/environment/llm_factory.py
@@ -5,7 +5,9 @@ from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 from langchain.chat_models import ChatOpenAI
 
 from moview.utils.singleton_meta_class import SingletonMeta
-from moview.environment.environment_loader import EnvironmentLoader, EnvironmentEnum
+from moview.environment.environment_loader import EnvironmentLoader
+
+OPENAI_API_KEY_PARAM = "openai-api-key"
 
 
 # 아래 코드는 팩토리 메서드 패턴이나 추상 팩토리 패턴이 적용된 것이 아닙니다.
@@ -13,11 +15,11 @@ from moview.environment.environment_loader import EnvironmentLoader, Environment
 class LLMModelFactory:
     """
     정적 메서드는 self를 받지 않으므로 인스턴스 속성에는 접근할 수 없습니다. 그래서 보통 정적 메서드는 인스턴스 속성, 인스턴스 메서드가 필요 없을 때 사용합니다.
-    정적 메서드는 m순수 함수(pure function)를 만들 때 사용합니다. 순수 함수는 부수 효과(side effect)가 없고 입력 값이 같으면 언제나 같은 출력 값을 반환합니다. 즉, 정적 메서드는 인스턴스의 상태를 변화시키지 않는 메서드를 만들 때 사용합니다.
+    정적 메서드는 순수 함수(pure function)를 만들 때 사용합니다. 순수 함수는 부수 효과(side effect)가 없고 입력 값이 같으면 언제나 같은 출력 값을 반환합니다. 즉, 정적 메서드는 인스턴스의 상태를 변화시키지 않는 메서드를 만들 때 사용합니다.
     """
 
     @staticmethod
     def create_chat_open_ai(temperature: float) -> ChatOpenAI:
-        return ChatOpenAI(openai_api_key=EnvironmentLoader.get_open_ai_key(),
+        return ChatOpenAI(openai_api_key=EnvironmentLoader.getenv(OPENAI_API_KEY_PARAM),
                           temperature=temperature, model_name='gpt-3.5-turbo', verbose=True, streaming=True,
                           callbacks=[StreamingStdOutCallbackHandler()])

--- a/moview/handlers/mongo_handler.py
+++ b/moview/handlers/mongo_handler.py
@@ -5,10 +5,10 @@ import traceback
 import pymongo
 from moview.environment.environment_loader import EnvironmentLoader
 
-DB_HOST_PARAM = "db-host"
-DB_PORT_PARAM = "db-port"
-DB_USERNAME_PARAM = "db-username"
-DB_PASSWORD_PARAM = "db-password"
+DB_HOST = "db-host"
+DB_PORT = "db-port"
+DB_USERNAME = "db-username"
+DB_PASSWORD = "db-password"
 
 
 class MongoHandler(logging.Handler):
@@ -20,11 +20,10 @@ class MongoHandler(logging.Handler):
         logging.Handler.__init__(self, level)
 
         # MongoClient를 만들고, database를 가져 온다.
-        self.conn = pymongo.MongoClient(host=EnvironmentLoader.get_param(DB_HOST_PARAM),
-                                        port=int(EnvironmentLoader.get_param(DB_PORT_PARAM)),
-                                        username=EnvironmentLoader.get_param(DB_USERNAME_PARAM),
-                                        password=EnvironmentLoader.get_param(DB_PASSWORD_PARAM))
-
+        self.conn = pymongo.MongoClient(host=EnvironmentLoader.getenv(DB_HOST),
+                                        port=int(EnvironmentLoader.getenv(DB_PORT)),
+                                        username=EnvironmentLoader.getenv(DB_USERNAME),
+                                        password=EnvironmentLoader.getenv(DB_PASSWORD))
         self.db = self.conn.get_database(database_name)
 
         # 데이터베이스 컬렉션을 가져온다


### PR DESCRIPTION
## 환경 변수 호출 메소드 통일
- 모든 환경 변수 호출은 `EnvironmentLoader.getenv("환경 변수 이름")`으로 통일
  - 이 때, `환경 변수 이름`은 **AWS SSM**을 위하여 `"소문자", "구분자는 -"`로 통일
- 시스템 환경 변수에 `MOVIEW_CORE_ENV` 값이 `local`로 설정 되어 있을 땐 **시스템 환경 변수 값**을 호출하고, `dev`, `sta`, `env`로 설정 되어 있으면 **AWS SSM 파라미터 스토어**에서 환경 변수 값 호출

## local에 환경 변수 저장시 주의점
- 시스템 환경 변수에 저장되는 환경 변수 이름은 `"대문자", "구분자는 _"`, 환경 변수 값은 `"소문자"`
```
(예시)
MOVIEW_CORE_ENV = local
DB_HOST = localhost
```