### PR TITLE
fix: Request Timeout 600s > 60s

### DIFF
--- a/moview/environment/llm_factory.py
+++ b/moview/environment/llm_factory.py
@@ -19,7 +19,7 @@ class LLMModelFactory:
     """
 
     @staticmethod
-    def create_chat_open_ai(temperature: float) -> ChatOpenAI:
+    def create_chat_open_ai(temperature: float, request_timeout: int = 60) -> ChatOpenAI:
         return ChatOpenAI(openai_api_key=EnvironmentLoader.getenv(OPENAI_API_KEY_PARAM),
                           temperature=temperature, model_name='gpt-3.5-turbo', verbose=True, streaming=True,
-                          callbacks=[StreamingStdOutCallbackHandler()])
+                          callbacks=[StreamingStdOutCallbackHandler()], request_timeout=request_timeout)


### PR DESCRIPTION
## OpenAI API Request Timeout

RequestTimeout의 기본값이 600초로 설정되어 있어서,
60초를 기본값으로 사용하도록 변경함.