### PR TITLE
feat: CORS Resource 변경

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,12 @@
 from moview import app
 from flask_cors import CORS
 
-CORS(app, resources={r"/api/*": {"origins": "http://localhost:3000"}}, supports_credentials=True)
+allowed_origins = [
+    "http://localhost:3000",
+    "https://moview.io",
+]
+
+CORS(app, resources={r"/*": {"origins": allowed_origins}}, supports_credentials=True)
 
 if __name__ == '__main__':
     app.run(host="0.0.0.0", port=5005, debug=True)


### PR DESCRIPTION
CORS 설정에서 허용할 origin에 moview.io를 추가함.
API Endpoint가 /api로 시작하지 않으므로, root를 허용으로 변경함.