### PR TITLE
가볍게 면접을 경험할 수 있는 모드 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,7 @@
 
 ## MVP v2 기준
 
-### API 명세서
-
-#### /interview/session
-
-```
-method : POST
-request: X
-response: cookie(세션id)
-description: 플라스크 세션 발급용 API.
-GPT call: X
-```
+### API 명세서 (핵심 기능만 포함)
 
 ***
 
@@ -115,10 +105,6 @@ GPT call: O
 ```
 
 response json
-
-아래 json은 Answer 엔티티에서 불러오는 것이다. 특히, question_id는 Answer 엔티티의 외래키인 question_id를 뜻한다!
-프론트엔드에서는 question_id와 묶어서 evaluation을 저장하는게?
-
 ```json
 {
   "evaluations": [
@@ -169,9 +155,9 @@ request json
 
 ***
 
-### 테스트 커버리지
+### 테스트 커버리지 (v2 기준)
 
-moview 디렉토리 기준 라인 커버리지 88% (v1 기준)
+moview 디렉토리 기준 file coverage 67%, line coverage 92%
 ***
 
 ### 디렉토리 트리
@@ -186,60 +172,84 @@ moview 디렉토리에서 'tree -I '__pycache__|*.pyc|__init__.py'' 명령어를
 │   ├── db
 │   │   ├── mongo_config.py
 │   │   └── mongo_handler.py
-│   └── loggers
-│       └── mongo_logger.py
+│   ├── jwt
+│   │   └── jwt_config.py
+│   ├── loggers
+│   │   └── mongo_logger.py
+│   └── oauth
+│       └── oauth_config.py
 ├── controller
 │   ├── answer_controller.py
 │   ├── evaluation_controller.py
 │   ├── feedback_controller.py
 │   ├── input_data_controller.py
-│   └── interview_controller.py
+│   ├── light_mode_controller.py
+│   └── oauth
+│       ├── oauth_controller.py
+│       └── oauth_controller_helper.py
 ├── domain
 │   └── entity
 │       ├── input_data
 │       │   ├── coverletter_document.py
 │       │   └── initial_input_data_document.py
-│       ├── interview_session_document.py
-│       └── question_answer
-│           ├── answer.py
-│           └── question.py
+│       ├── interview_document.py
+│       ├── question_answer
+│       │   ├── answer.py
+│       │   └── question.py
+│       └── user
+│           └── user.py
 ├── environment
 │   ├── environment_loader.py
 │   └── llm_factory.py
+├── exception
+│   ├── evaluation_parse_error.py
+│   ├── initial_question_parse_error.py
+│   ├── light_question_parse_error.py
+│   └── retry_execution_error.py
 ├── modules
 │   ├── answer_evaluator
-│   │   ├── answer_analyzer.py
-│   │   └── answer_scorer.py
+│   │   └── answer_evaluator.py
 │   ├── input
 │   │   ├── initial_question_giver.py
 │   │   └── input_analyzer.py
+│   ├── light
+│   │   └── light_question_giver.py
 │   └── question_generator
 │       └── followup_question_giver.py
 ├── repository
 │   ├── input_data
 │   │   └── input_data_repository.py
 │   ├── interview_repository.py
-│   └── question_answer
-│       └── question_answer_repository.py
+│   ├── question_answer
+│   │   └── question_answer_repository.py
+│   └── user
+│       └── user_repository.py
 ├── service
 │   ├── answer_service.py
+│   ├── evaluation_service.py
 │   ├── feedback_service.py
 │   ├── input_data_service.py
-│   └── interview_service.py
+│   ├── interview_service.py
+│   ├── light_mode_service.py
+│   └── user_service.py
 └── utils
+    ├── async_controller.py
     ├── prompt_loader
     │   ├── json
     │   │   ├── AnswerAnalyzer.json
     │   │   ├── AnswerCategoryClassifier.json
+    │   │   ├── AnswerEvaluator.json
     │   │   ├── AnswerScorer.json
     │   │   ├── AnswerSubCategoryClassifier.json
     │   │   ├── AnswerValidator.json
     │   │   ├── FollowUpQuestionGiver.json
     │   │   ├── InitialQuestionGiver.json
     │   │   ├── InputAnalyzer.json
+    │   │   ├── LightQuestionGiver.json
     │   │   └── helpme.md
     │   └── prompt_loader.py
     ├── prompt_parser.py
+    ├── retry_decorator.py
     └── singleton_meta_class.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,53 @@ response json
 
 ***
 
+#### /interview/light
+
+```
+method : POST
+request: json(면접자 이름, 회사, 직군)
+response: json(초기 질문 n개에 대한 데이터{"objectId":id, ""}, 인터뷰 아이디)
+description: 초기 질문 받아오는 API (light mode)
+GPT call: O
+```
+
+request json
+
+```json
+{
+    "interviewee_name":"tester",
+    "company_name":"Facebook",
+    "job_group":"Backend"
+}
+
+```
+
+response json
+
+```json
+{
+  "message": {
+    "light_questions": [
+      {
+        "question_id": "초기 질문 id",
+        "content": "GPT 결과"
+      },
+      {
+        "question_id": "초기 질문 id",
+        "content": "GPT 결과"
+      },
+      {
+        "question_id": "초기 질문 id",
+        "content": "GPT 결과"
+      }
+    ],
+    "interview_id": "인터뷰 id"
+  }
+}
+```
+
+***
+
 #### /interview/answer
 
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,17 @@
 
 ## MVP v2 기준
 
-### API 명세서 (핵심 기능만 포함)
+### 기술 스택
+<img src="https://img.shields.io/badge/python-3776AB?style=for-the-badge&logo=python&logoColor=white"> 
+<img src="https://img.shields.io/badge/flask-000000?style=for-the-badge&logo=flask&logoColor=white">
+<img src="https://img.shields.io/badge/mongoDB-47A248?style=for-the-badge&logo=MongoDB&logoColor=white">
+<img src="https://img.shields.io/badge/Langchain-412991?style=for-the-badge&logo=OpenAI&logoColor=white">
+<img src="https://img.shields.io/badge/GitHub Actions-2088FF?style=for-the-badge&logo=GitHubActions&logoColor=white">
+<img src="https://img.shields.io/badge/amazon aws-232F3E?style=for-the-badge&logo=amazonaws&logoColor=white">
+
+***
+
+### API 명세서 (인증 / 인가 관련 명세서는 미포함)
 
 ***
 
@@ -65,7 +75,7 @@ response json
 
 ```
 method : POST
-request: json(면접자 이름, 회사, 직군)
+request: json(면접자 이름, 회사, 직군, 직무면접 키워드)
 response: json(초기 질문 n개에 대한 데이터{"objectId":id, ""}, 인터뷰 아이디)
 description: 초기 질문 받아오는 API (light mode)
 GPT call: O
@@ -77,7 +87,8 @@ request json
 {
     "interviewee_name":"tester",
     "company_name":"Facebook",
-    "job_group":"Backend"
+    "job_group":"Backend",
+    "keyword":"아파치 카프카"
 }
 
 ```

--- a/app.py
+++ b/app.py
@@ -7,7 +7,8 @@ from flask_jwt_extended import JWTManager
 import random
 import string
 
-from moview.controller import input_data_controller, answer_controller, evaluation_controller, feedback_controller
+from moview.controller import input_data_controller, answer_controller, evaluation_controller, feedback_controller, \
+    light_mode_controller
 from moview.controller.oauth import oauth_controller
 
 # Flask App 생성
@@ -23,6 +24,7 @@ CORS(app, resources={r"/*": {"origins": allowed_origins}}, supports_credentials=
 """This module patches asyncio to allow nested use of `asyncio.run` and `loop.run_until_complete`."""
 __import__("nest_asyncio").apply()
 
+
 def set_moview_config():
     """
     Flask App에 API 추가
@@ -36,6 +38,7 @@ def set_moview_config():
     api.add_namespace(answer_controller.api, '/interview')
     api.add_namespace(evaluation_controller.api, '/interview')
     api.add_namespace(feedback_controller.api, '/interview')
+    api.add_namespace(light_mode_controller.api, '/interview')
 
     # oauth api
     api.add_namespace(oauth_controller.api, '/interview')
@@ -52,6 +55,7 @@ def set_jwt_config():
     app.config['JWT_ACCESS_TOKEN_EXPIRES'] = JWTConfig.get_jwt_access_token_expires()
     app.config['JWT_REFRESH_TOKEN_EXPIRES'] = JWTConfig.get_jwt_refresh_token_expires()
     JWTManager(app)
+
 
 if __name__ == '__main__':
     set_moview_config()

--- a/moview/config/container/container_config.py
+++ b/moview/config/container/container_config.py
@@ -2,6 +2,7 @@ from moview.config.db.mongo_config import MongoConfig
 from moview.modules.input import InputAnalyzer, InitialQuestionGiver
 from moview.modules.question_generator import FollowUpQuestionGiver
 from moview.modules.answer_evaluator import AnswerEvaluator
+from moview.modules.light.light_question_giver import LightQuestionGiver
 from moview.repository.input_data.input_data_repository import InputDataRepository
 from moview.repository.interview_repository import InterviewRepository
 from moview.repository.question_answer.question_answer_repository import QuestionAnswerRepository
@@ -10,6 +11,7 @@ from moview.service.input_data_service import InputDataService
 from moview.service.answer_service import AnswerService
 from moview.service.evaluation_service import EvaluationService
 from moview.service.feedback_service import FeedbackService
+from moview.service.light_mode_service import LightModeService
 from moview.utils.prompt_loader import PromptLoader
 from moview.repository.user.user_repository import UserRepository
 from moview.service.user_service import UserService
@@ -26,6 +28,7 @@ class ContainerConfig:
         self.initial_input_analyzer = InputAnalyzer(prompt_loader=self.prompt_loader)
         self.followup_question_giver = FollowUpQuestionGiver(prompt_loader=self.prompt_loader)
         self.answer_evaluator = AnswerEvaluator(prompt_loader=self.prompt_loader)
+        self.light_question_giver = LightQuestionGiver(prompt_loader=self.prompt_loader)
 
         # Repository
         self.interview_repository = InterviewRepository(mongo_config=self.mongo_config)
@@ -54,3 +57,9 @@ class ContainerConfig:
             answer_evaluator=self.answer_evaluator
         )
         self.feedback_service = FeedbackService(question_answer_repository=self.question_answer_repository)
+
+        self.light_mode_service = LightModeService(
+            input_data_repository=self.input_data_repository,
+            question_answer_repository=self.question_answer_repository,
+            light_question_giver=self.light_question_giver
+        )

--- a/moview/config/db/mongo_constant.py
+++ b/moview/config/db/mongo_constant.py
@@ -1,0 +1,4 @@
+DB_HOST = "db-host"
+DB_PORT = "db-port"
+DB_USERNAME = "db-username"
+DB_PASSWORD = "db-password"

--- a/moview/config/db/mongo_handler.py
+++ b/moview/config/db/mongo_handler.py
@@ -4,11 +4,7 @@ import traceback
 
 import pymongo
 from moview.environment.environment_loader import EnvironmentLoader
-
-DB_HOST = "db-host"
-DB_PORT = "db-port"
-DB_USERNAME = "db-username"
-DB_PASSWORD = "db-password"
+from moview.config.db.mongo_constant import DB_HOST, DB_PORT, DB_USERNAME, DB_PASSWORD
 
 
 class MongoHandler(logging.Handler):

--- a/moview/controller/answer_controller.py
+++ b/moview/controller/answer_controller.py
@@ -5,6 +5,7 @@ from http import HTTPStatus
 
 from moview.config.container.container_config import ContainerConfig
 from moview.config.loggers.mongo_logger import *
+from moview.utils.timing_decorator import api_timing_decorator
 
 api = Namespace('answer', description='answer api')
 
@@ -13,6 +14,7 @@ api = Namespace('answer', description='answer api')
 class AnswerConstructor(Resource):
 
     @jwt_required()
+    @api_timing_decorator
     def post(self):
         user_id = str(get_jwt_identity())
         request_body = request.get_json()

--- a/moview/controller/evaluation_controller.py
+++ b/moview/controller/evaluation_controller.py
@@ -6,6 +6,7 @@ from http import HTTPStatus
 from moview.config.container.container_config import ContainerConfig
 from moview.config.loggers.mongo_logger import *
 from moview.utils.async_controller import async_controller
+from moview.utils.timing_decorator import api_timing_decorator
 
 api = Namespace('evaluation', description='evaluation api')
 
@@ -14,6 +15,7 @@ api = Namespace('evaluation', description='evaluation api')
 class EvaluationConstructor(Resource):
 
     @jwt_required()
+    @api_timing_decorator
     @async_controller
     async def post(self):
         user_id = str(get_jwt_identity())

--- a/moview/controller/feedback_controller.py
+++ b/moview/controller/feedback_controller.py
@@ -5,6 +5,7 @@ from http import HTTPStatus
 
 from moview.config.container.container_config import ContainerConfig
 from moview.config.loggers.mongo_logger import *
+from moview.utils.timing_decorator import api_timing_decorator
 
 api = Namespace('feedback', description='feedback api')
 
@@ -13,6 +14,7 @@ api = Namespace('feedback', description='feedback api')
 class FeedbackConstructor(Resource):
 
     @jwt_required()
+    @api_timing_decorator
     def post(self):
         user_id = str(get_jwt_identity())
         request_body = request.get_json()

--- a/moview/controller/input_data_controller.py
+++ b/moview/controller/input_data_controller.py
@@ -6,6 +6,7 @@ from http import HTTPStatus
 from moview.config.container.container_config import ContainerConfig
 from moview.config.loggers.mongo_logger import *
 from moview.utils.async_controller import async_controller
+from moview.utils.timing_decorator import api_timing_decorator
 
 api = Namespace('input_data', description='input data api')
 
@@ -14,6 +15,7 @@ api = Namespace('input_data', description='input data api')
 class InputDataConstructor(Resource):
 
     @jwt_required()
+    @api_timing_decorator
     @async_controller
     async def post(self):
         user_id = str(get_jwt_identity())

--- a/moview/controller/light_mode_controller.py
+++ b/moview/controller/light_mode_controller.py
@@ -1,0 +1,60 @@
+from flask import make_response, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from flask_restx import Resource, Namespace
+from http import HTTPStatus
+
+from moview.config.container.container_config import ContainerConfig
+from moview.config.loggers.mongo_logger import *
+
+api = Namespace('light_mode', description='light mode api')
+
+
+@api.route('/light')
+class LightModeConstructor(Resource):
+
+    @jwt_required()
+    def post(self):
+        user_id = str(get_jwt_identity())
+
+        request_body = request.get_json()
+
+        interviewee_name = request_body['interviewee_name']
+        company_name = request_body['company_name']
+        job_group = request_body['job_group']
+
+        interview_service = ContainerConfig().interview_service
+        light_mode_service = ContainerConfig().light_mode_service
+
+        result = light_mode_service.ask_light_question_to_interviewee(
+            interviewee_name=interviewee_name,
+            company_name=company_name,
+            job_group=job_group)
+
+        # Parse Error 발생했을 경우 500 에러 반환
+        if result is None:
+            return make_response(jsonify(
+                {'message': {
+                    'light_questions': None,
+                    'interview_id': None
+                }}
+            ), HTTPStatus.INTERNAL_SERVER_ERROR)
+
+        interview_document_id = interview_service.create_interview(
+            user_id=user_id,
+            input_data_document_id=result['input_data_document']
+        )
+
+        execution_trace_logger("LIGHT MODE CONTROLLER: POST",
+                               user_id=user_id,
+                               interviewee_name=interviewee_name,
+                               company_name=company_name,
+                               job_group=job_group,
+                               interview_document_id=interview_document_id)
+
+        return make_response(jsonify(
+            {'message': {
+                'light_questions': [{"question_id": str(object_id), "content": question} for object_id, question in
+                                    result['question_document_list']],
+                'interview_id': interview_document_id
+            }}
+        ), HTTPStatus.OK)

--- a/moview/controller/light_mode_controller.py
+++ b/moview/controller/light_mode_controller.py
@@ -5,6 +5,7 @@ from http import HTTPStatus
 
 from moview.config.container.container_config import ContainerConfig
 from moview.config.loggers.mongo_logger import *
+from moview.utils.timing_decorator import api_timing_decorator
 
 api = Namespace('light_mode', description='light mode api')
 
@@ -13,6 +14,7 @@ api = Namespace('light_mode', description='light mode api')
 class LightModeConstructor(Resource):
 
     @jwt_required()
+    @api_timing_decorator
     def post(self):
         user_id = str(get_jwt_identity())
 

--- a/moview/controller/light_mode_controller.py
+++ b/moview/controller/light_mode_controller.py
@@ -21,6 +21,7 @@ class LightModeConstructor(Resource):
         interviewee_name = request_body['interviewee_name']
         company_name = request_body['company_name']
         job_group = request_body['job_group']
+        keyword = request_body['keyword']
 
         interview_service = ContainerConfig().interview_service
         light_mode_service = ContainerConfig().light_mode_service
@@ -28,7 +29,7 @@ class LightModeConstructor(Resource):
         result = light_mode_service.ask_light_question_to_interviewee(
             interviewee_name=interviewee_name,
             company_name=company_name,
-            job_group=job_group)
+            job_group=job_group, keyword=keyword)
 
         # Parse Error 발생했을 경우 500 에러 반환
         if result is None:
@@ -49,6 +50,7 @@ class LightModeConstructor(Resource):
                                interviewee_name=interviewee_name,
                                company_name=company_name,
                                job_group=job_group,
+                               keyword=keyword,
                                interview_document_id=interview_document_id)
 
         return make_response(jsonify(

--- a/moview/domain/entity/input_data/initial_input_data_document.py
+++ b/moview/domain/entity/input_data/initial_input_data_document.py
@@ -7,6 +7,6 @@ class InitialInputData(BaseModel):
     interviewee_name: str
     company_name: str
     job_group: str
-    recruit_announcement: str
+    recruit_announcement: Optional[str]  # light mode 인 경우 None
     coverletter_id_list: List[Dict[str, Optional[str]]] = []
     created_at: str = datetime.now().strftime('%Y-%m-%d %H:%M:%S')

--- a/moview/domain/entity/input_data/initial_input_data_document.py
+++ b/moview/domain/entity/input_data/initial_input_data_document.py
@@ -7,6 +7,7 @@ class InitialInputData(BaseModel):
     interviewee_name: str
     company_name: str
     job_group: str
+    keyword: Optional[str]
     recruit_announcement: Optional[str]  # light mode 인 경우 None
     coverletter_id_list: List[Dict[str, Optional[str]]] = []
     created_at: str = datetime.now().strftime('%Y-%m-%d %H:%M:%S')

--- a/moview/exception/light_question_parse_error.py
+++ b/moview/exception/light_question_parse_error.py
@@ -1,0 +1,5 @@
+class LightQuestionParseError(Exception):
+
+    def __init__(self, message="Light QUESTION PARSE ERROR"):
+        self.message = message
+        super().__init__(self.message)

--- a/moview/modules/light/light_question_giver.py
+++ b/moview/modules/light/light_question_giver.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from langchain import LLMChain
 from langchain.prompts.chat import (
@@ -23,16 +23,29 @@ class LightQuestionGiver(metaclass=SingletonMeta):
         self.llm = LLMModelFactory.create_chat_open_ai(model_name="gpt-3.5-turbo-16k", temperature=0.7)
 
     @retry()
-    def give_light_questions_by_input_data(self, job_group: str, question_count: int) -> List[str]:
+    def give_light_questions_by_input_data(self, job_group: str, keyword: Optional[str], question_count: int) \
+            -> List[str]:
         """
 
         Args:
             job_group: 직군
+            keyword: 직무 면접 키워드 문자열
             question_count: 출제할 질문 개수
 
         Returns: 직무 중심으로 출제된 질문 리스트 (light mode 전용)
 
         """
+
+        human_message = HumanMessagePromptTemplate.from_template(
+            """
+             양식을 지켜서 직무 기술 면접 질문을 생성하세요.    
+             """
+        ) if keyword is None else HumanMessagePromptTemplate.from_template(
+            f"""
+            양식을 지켜서 {keyword}에 대한 직무 기술 면접 질문을 생성하세요.    
+            """
+        )
+
         prompt = ChatPromptTemplate(
             messages=[
                 SystemMessagePromptTemplate.from_template(
@@ -40,11 +53,7 @@ class LightQuestionGiver(metaclass=SingletonMeta):
                         job_group=job_group,
                         question_count=question_count)
                 ),
-                HumanMessagePromptTemplate.from_template(
-                    """
-                    양식을 지켜서 직무 기술 면접 질문을 생성하세요.    
-                    """
-                )
+                human_message
             ]
         )
 

--- a/moview/modules/light/light_question_giver.py
+++ b/moview/modules/light/light_question_giver.py
@@ -50,7 +50,7 @@ class LightQuestionGiver(metaclass=SingletonMeta):
 
         chain = LLMChain(llm=self.llm, prompt=prompt)
 
-        prompt_result = chain.run()
+        prompt_result = chain.predict()
 
         prompt_result_logger("light question prompt result", prompt_result=prompt_result)
 

--- a/moview/modules/light/light_question_giver.py
+++ b/moview/modules/light/light_question_giver.py
@@ -13,6 +13,7 @@ from moview.environment.llm_factory import LLMModelFactory
 from moview.config.loggers.mongo_logger import prompt_result_logger
 from moview.utils.prompt_parser import PromptParser
 from moview.utils.singleton_meta_class import SingletonMeta
+from moview.utils.retry_decorator import retry
 
 
 class LightQuestionGiver(metaclass=SingletonMeta):
@@ -21,6 +22,7 @@ class LightQuestionGiver(metaclass=SingletonMeta):
         self.prompt = prompt_loader.load_prompt_json(LightQuestionGiver.__name__)
         self.llm = LLMModelFactory.create_chat_open_ai(model_name="gpt-3.5-turbo-16k", temperature=0.7)
 
+    @retry()
     def give_light_questions_by_input_data(self, job_group: str, question_count: int) -> List[str]:
         """
 

--- a/moview/modules/light/light_question_giver.py
+++ b/moview/modules/light/light_question_giver.py
@@ -1,0 +1,60 @@
+from typing import List
+
+from langchain import LLMChain
+from langchain.prompts.chat import (
+    SystemMessagePromptTemplate,
+    ChatPromptTemplate,
+    HumanMessagePromptTemplate
+)
+
+from moview.exception.light_question_parse_error import LightQuestionParseError
+from moview.utils.prompt_loader import PromptLoader
+from moview.environment.llm_factory import LLMModelFactory
+from moview.config.loggers.mongo_logger import prompt_result_logger
+from moview.utils.prompt_parser import PromptParser
+from moview.utils.singleton_meta_class import SingletonMeta
+
+
+class LightQuestionGiver(metaclass=SingletonMeta):
+
+    def __init__(self, prompt_loader: PromptLoader):
+        self.prompt = prompt_loader.load_prompt_json(LightQuestionGiver.__name__)
+        self.llm = LLMModelFactory.create_chat_open_ai(model_name="gpt-3.5-turbo-16k", temperature=0.7)
+
+    def give_light_questions_by_input_data(self, job_group: str, question_count: int) -> List[str]:
+        """
+
+        Args:
+            job_group: 직군
+            question_count: 출제할 질문 개수
+
+        Returns: 직무 중심으로 출제된 질문 리스트 (light mode 전용)
+
+        """
+        prompt = ChatPromptTemplate(
+            messages=[
+                SystemMessagePromptTemplate.from_template(
+                    self.prompt.format(
+                        job_group=job_group,
+                        question_count=question_count)
+                ),
+                HumanMessagePromptTemplate.from_template(
+                    """
+                    양식을 지켜서 직무 기술 면접 질문을 생성하세요.    
+                    """
+                )
+            ]
+        )
+
+        chain = LLMChain(llm=self.llm, prompt=prompt)
+
+        prompt_result = chain.run()
+
+        prompt_result_logger("light question prompt result", prompt_result=prompt_result)
+
+        parse_question = PromptParser.parse_question(prompt_result)
+
+        if parse_question is not None:
+            return parse_question
+        else:
+            raise LightQuestionParseError()

--- a/moview/repository/input_data/input_data_repository.py
+++ b/moview/repository/input_data/input_data_repository.py
@@ -10,11 +10,7 @@ from moview.domain.entity.input_data.initial_input_data_document import InitialI
 from moview.utils.singleton_meta_class import SingletonMeta
 from bson import ObjectId
 from moview.environment.environment_loader import EnvironmentLoader
-
-DB_HOST = "db-host"
-DB_PORT = "db-port"
-DB_USERNAME = "db-username"
-DB_PASSWORD = "db-password"
+from moview.config.db.mongo_constant import DB_HOST, DB_PORT, DB_USERNAME, DB_PASSWORD
 
 
 class InputDataRepository(metaclass=SingletonMeta):

--- a/moview/repository/input_data/input_data_repository.py
+++ b/moview/repository/input_data/input_data_repository.py
@@ -42,6 +42,11 @@ class InputDataRepository(metaclass=SingletonMeta):
         execution_trace_logger(msg="SAVE_INITIAL_INPUT_DATA")
         return self.collection.insert_one(initial_input_data_model)
 
+    def save_for_light_mode(self, initial_input_data: InitialInputData) -> InsertOneResult:
+        initial_input_data_model = initial_input_data.dict()
+        execution_trace_logger(msg="SAVE_INITIAL_INPUT_DATA_FOR_LIGHT_MODE")
+        return self.collection.insert_one(initial_input_data_model)
+
     def find_cover_letter_by_object_id(self, coverletter_id: Dict[str, Optional[str]]) -> Optional[Dict[str, Any]]:
         execution_trace_logger(msg="FIND_COVER_LETTER_BY_OBJECT_ID", object_id=coverletter_id["#id"])
         # "#db"와 "#ref"를 이용해 document가 있는 collection에 접속함.

--- a/moview/repository/interview_repository.py
+++ b/moview/repository/interview_repository.py
@@ -7,11 +7,7 @@ from moview.utils.singleton_meta_class import SingletonMeta
 from moview.config.loggers.mongo_logger import execution_trace_logger
 from moview.domain.entity.interview_document import Interview
 from moview.environment.environment_loader import EnvironmentLoader
-
-DB_HOST = "db-host"
-DB_PORT = "db-port"
-DB_USERNAME = "db-username"
-DB_PASSWORD = "db-password"
+from moview.config.db.mongo_constant import DB_HOST, DB_PORT, DB_USERNAME, DB_PASSWORD
 
 
 class InterviewRepository(metaclass=SingletonMeta):

--- a/moview/repository/question_answer/question_answer_repository.py
+++ b/moview/repository/question_answer/question_answer_repository.py
@@ -8,11 +8,7 @@ from moview.domain.entity.question_answer.question import Question
 from moview.domain.entity.question_answer.answer import Answer
 from moview.config.loggers.mongo_logger import execution_trace_logger, error_logger
 from moview.environment.environment_loader import EnvironmentLoader
-
-DB_HOST = "db-host"
-DB_PORT = "db-port"
-DB_USERNAME = "db-username"
-DB_PASSWORD = "db-password"
+from moview.config.db.mongo_constant import DB_HOST, DB_PORT, DB_USERNAME, DB_PASSWORD
 
 
 class QuestionAnswerRepository(metaclass=SingletonMeta):

--- a/moview/repository/user/user_repository.py
+++ b/moview/repository/user/user_repository.py
@@ -6,11 +6,16 @@ from moview.config.db.mongo_config import MongoConfig
 from moview.utils.singleton_meta_class import SingletonMeta
 from moview.config.loggers.mongo_logger import execution_trace_logger
 from moview.domain.entity.user.user import OauthUser
+from moview.config.db.mongo_constant import DB_HOST, DB_PORT, DB_USERNAME, DB_PASSWORD
+from moview.environment.environment_loader import EnvironmentLoader
 
 
 class UserRepository(metaclass=SingletonMeta):
     def __init__(self, mongo_config: MongoConfig):
-        self.client = MongoClient(mongo_config.host, mongo_config.port)
+        self.client = MongoClient(host=EnvironmentLoader.getenv(DB_HOST),
+                                  port=int(EnvironmentLoader.getenv(DB_PORT)),
+                                  username=EnvironmentLoader.getenv(DB_USERNAME),
+                                  password=EnvironmentLoader.getenv(DB_PASSWORD))
         self.db = self.client[mongo_config.db_name]
         self.collection = self.db["user"]
 

--- a/moview/service/light_mode_service.py
+++ b/moview/service/light_mode_service.py
@@ -1,0 +1,93 @@
+from typing import List, Dict, Any
+
+from moview.config.loggers.mongo_logger import error_logger, execution_trace_logger
+from moview.domain.entity.input_data.initial_input_data_document import InitialInputData
+from moview.domain.entity.question_answer.question import Question
+from moview.exception.light_question_parse_error import LightQuestionParseError
+from moview.modules.light.light_question_giver import LightQuestionGiver
+from moview.repository.input_data.input_data_repository import InputDataRepository
+from moview.repository.question_answer.question_answer_repository import QuestionAnswerRepository
+from moview.utils.singleton_meta_class import SingletonMeta
+
+
+class LightModeService(metaclass=SingletonMeta):
+
+    def __init__(self, input_data_repository: InputDataRepository,
+                 question_answer_repository: QuestionAnswerRepository,
+                 light_question_giver: LightQuestionGiver):
+        self.LIGHT_QUESTION_NUMBER = 6
+        self.input_data_repository = input_data_repository
+        self.question_answer_repository = question_answer_repository
+        self.light_question_giver = light_question_giver
+
+    def ask_light_question_to_interviewee(self, company_name: str, job_group: str) -> Dict[str, Any]:
+        """
+
+        Args:
+            company_name: 인터뷰 대상자 회사 이름
+            job_group: 인터뷰 대상자 직군
+
+        Returns: 직무 기술 중심 면접 질문 리스트
+
+        """
+
+        # light mode 면접 질문 생성
+        light_question_list = self.__make_light_questions_by_input_data(job_group=job_group)
+
+        # Initial Input Data Entity Model 생성 (Light mode라서 모집공고 None, 자소서 모델 None)
+        initial_input_data_model = self.__create_interviewee_data_entity_for_light_mode(company_name=company_name,
+                                                                                        job_group=job_group)
+
+        # Initial Input Data Document 저장
+        initial_input_document = self.input_data_repository.save_for_light_mode(
+            initial_input_data=initial_input_data_model)
+
+        # Initial Question Entity Model 생성 및 Document 저장
+        question_document_id_list = []
+        for question_content in light_question_list:
+            question_model = self.__create_question_entity(question_content=question_content)
+            question_document = self.question_answer_repository.save_question(question_model)
+            question_document_id_list.append(question_document.inserted_id)
+
+        execution_trace_logger("Save Light Question Document", initial_question_list=light_question_list)
+
+        return {
+            "input_data_document": {
+                "#ref": self.input_data_repository.collection.name,
+                "#id": str(initial_input_document.inserted_id),
+                "#db": self.input_data_repository.db.name
+            },
+            "question_document_list": list(zip(question_document_id_list, light_question_list))
+        }
+
+    def __make_light_questions_by_input_data(self, job_group: str) -> List[str]:
+        try:
+            light_questions = self.light_question_giver.give_light_questions_by_input_data(
+                job_group=job_group,
+                question_count=self.LIGHT_QUESTION_NUMBER
+            )
+
+            execution_trace_logger("Make Light Question", created_questions=light_questions)
+
+            return light_questions
+        except LightQuestionParseError:
+            error_logger("Light Question Parse Error")
+
+    @staticmethod
+    def __create_interviewee_data_entity_for_light_mode(company_name: str,
+                                                        job_group: str) -> InitialInputData:
+        # 도메인 모델 InitialInputData을 재사용한다. 이유는 다음과 같다.
+        # 이 모델에 모집공고만 None 처리하면 light mode 용 초기 데이터가 만들어지기 때문.
+        # 그리고 CoverLetter 모델 역시 만들 필요가 없어진다.
+        return InitialInputData(
+            company_name=company_name,
+            job_group=job_group,
+            recruit_announcement=None)
+
+    @staticmethod
+    def __create_question_entity(question_content: str) -> Question:
+        question_model = Question(
+            content=question_content,
+            feedback_score=0,
+        )
+        return question_model

--- a/moview/service/light_mode_service.py
+++ b/moview/service/light_mode_service.py
@@ -20,10 +20,12 @@ class LightModeService(metaclass=SingletonMeta):
         self.question_answer_repository = question_answer_repository
         self.light_question_giver = light_question_giver
 
-    def ask_light_question_to_interviewee(self, company_name: str, job_group: str) -> Dict[str, Any]:
+    def ask_light_question_to_interviewee(self, interviewee_name: str, company_name: str, job_group: str) -> Dict[
+        str, Any]:
         """
 
         Args:
+            interviewee_name: 인터뷰 대상자 이름 (jwt 적용 됬으므로 추후 삭제해야 할 칼럼)
             company_name: 인터뷰 대상자 회사 이름
             job_group: 인터뷰 대상자 직군
 
@@ -35,8 +37,10 @@ class LightModeService(metaclass=SingletonMeta):
         light_question_list = self.__make_light_questions_by_input_data(job_group=job_group)
 
         # Initial Input Data Entity Model 생성 (Light mode라서 모집공고 None, 자소서 모델 None)
-        initial_input_data_model = self.__create_interviewee_data_entity_for_light_mode(company_name=company_name,
-                                                                                        job_group=job_group)
+        initial_input_data_model = self.__create_interviewee_data_entity_for_light_mode(
+            interviewee_name=interviewee_name,
+            company_name=company_name,
+            job_group=job_group)
 
         # Initial Input Data Document 저장
         initial_input_document = self.input_data_repository.save_for_light_mode(
@@ -74,12 +78,13 @@ class LightModeService(metaclass=SingletonMeta):
             error_logger("Light Question Parse Error")
 
     @staticmethod
-    def __create_interviewee_data_entity_for_light_mode(company_name: str,
+    def __create_interviewee_data_entity_for_light_mode(interviewee_name: str, company_name: str,
                                                         job_group: str) -> InitialInputData:
         # 도메인 모델 InitialInputData을 재사용한다. 이유는 다음과 같다.
         # 이 모델에 모집공고만 None 처리하면 light mode 용 초기 데이터가 만들어지기 때문.
         # 그리고 CoverLetter 모델 역시 만들 필요가 없어진다.
         return InitialInputData(
+            interviewee_name=interviewee_name,
             company_name=company_name,
             job_group=job_group,
             recruit_announcement=None)

--- a/moview/service/light_mode_service.py
+++ b/moview/service/light_mode_service.py
@@ -20,22 +20,22 @@ class LightModeService(metaclass=SingletonMeta):
         self.question_answer_repository = question_answer_repository
         self.light_question_giver = light_question_giver
 
-    def ask_light_question_to_interviewee(self, interviewee_name: str, company_name: str, job_group: str) -> Optional[
-        Dict[
-            str, Any]]:
+    def ask_light_question_to_interviewee(self, interviewee_name: str, company_name: str, job_group: str,
+                                          keyword: Optional[str]) -> Optional[Dict[str, Any]]:
         """
 
         Args:
             interviewee_name: 인터뷰 대상자 이름 (jwt 적용 됬으므로 추후 삭제해야 할 칼럼)
             company_name: 인터뷰 대상자 회사 이름
             job_group: 인터뷰 대상자 직군
+            keyword: 인터뷰 대상자 직무 키워드 (nullable)
 
         Returns: 직무 기술 중심 면접 질문 리스트
 
         """
 
         # light mode 면접 질문 생성
-        light_question_list = self._make_light_questions_by_input_data(job_group=job_group)
+        light_question_list = self._make_light_questions_by_input_data(job_group=job_group, keyword=keyword)
 
         if len(light_question_list) == 0:
             return None
@@ -68,10 +68,11 @@ class LightModeService(metaclass=SingletonMeta):
             "question_document_list": list(zip(question_document_id_list, light_question_list))
         }
 
-    def _make_light_questions_by_input_data(self, job_group: str) -> List[str]:
+    def _make_light_questions_by_input_data(self, job_group: str, keyword: Optional[str]) -> List[str]:
         try:
             light_questions = self.light_question_giver.give_light_questions_by_input_data(
                 job_group=job_group,
+                keyword=keyword,
                 question_count=self.LIGHT_QUESTION_NUMBER
             )
 

--- a/moview/service/light_mode_service.py
+++ b/moview/service/light_mode_service.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 
 from moview.config.loggers.mongo_logger import error_logger, execution_trace_logger
 from moview.domain.entity.input_data.initial_input_data_document import InitialInputData
@@ -20,8 +20,9 @@ class LightModeService(metaclass=SingletonMeta):
         self.question_answer_repository = question_answer_repository
         self.light_question_giver = light_question_giver
 
-    def ask_light_question_to_interviewee(self, interviewee_name: str, company_name: str, job_group: str) -> Dict[
-        str, Any]:
+    def ask_light_question_to_interviewee(self, interviewee_name: str, company_name: str, job_group: str) -> Optional[
+        Dict[
+            str, Any]]:
         """
 
         Args:
@@ -34,7 +35,10 @@ class LightModeService(metaclass=SingletonMeta):
         """
 
         # light mode 면접 질문 생성
-        light_question_list = self.__make_light_questions_by_input_data(job_group=job_group)
+        light_question_list = self._make_light_questions_by_input_data(job_group=job_group)
+
+        if len(light_question_list) == 0:
+            return None
 
         # Initial Input Data Entity Model 생성 (Light mode라서 모집공고 None, 자소서 모델 None)
         initial_input_data_model = self.__create_interviewee_data_entity_for_light_mode(
@@ -64,7 +68,7 @@ class LightModeService(metaclass=SingletonMeta):
             "question_document_list": list(zip(question_document_id_list, light_question_list))
         }
 
-    def __make_light_questions_by_input_data(self, job_group: str) -> List[str]:
+    def _make_light_questions_by_input_data(self, job_group: str) -> List[str]:
         try:
             light_questions = self.light_question_giver.give_light_questions_by_input_data(
                 job_group=job_group,
@@ -76,6 +80,8 @@ class LightModeService(metaclass=SingletonMeta):
             return light_questions
         except LightQuestionParseError:
             error_logger("Light Question Parse Error")
+
+            return []
 
     @staticmethod
     def __create_interviewee_data_entity_for_light_mode(interviewee_name: str, company_name: str,

--- a/moview/utils/timing_decorator.py
+++ b/moview/utils/timing_decorator.py
@@ -1,5 +1,5 @@
 import time
-from moview.environment.environment_loader import EnvironmentLoader, EnvironmentEnum
+from moview.environment.environment_loader import EnvironmentLoader
 from moview.config.loggers.mongo_logger import execution_trace_logger
 
 
@@ -22,7 +22,7 @@ def api_timing_decorator(f):
         if EnvironmentLoader.getenv("MOVIEW_CORE_ENV") == "local":
             print(message)
         else:
-            execution_trace_logger.info(elapsed=message)
+            execution_trace_logger(elapsed=message)
 
         return ret
 

--- a/moview/utils/timing_decorator.py
+++ b/moview/utils/timing_decorator.py
@@ -1,13 +1,14 @@
 import time
-import inspect
+from moview.environment.environment_loader import EnvironmentLoader, EnvironmentEnum
+from moview.config.loggers.mongo_logger import execution_trace_logger
 
 
 # api 호출 시간을 측정하는 데코레이터입니다. 컨트롤러에만 사용바랍니다.
 def api_timing_decorator(f):
     def wrap(*args, **kwargs):
-        time1 = time.time()
+        start_time = time.time()
         ret = f(*args, **kwargs)
-        time2 = time.time()
+        end_time = time.time()
 
         # 첫 번째 인수가 self인지 확인하여 메서드 호출 여부를 확인합니다.
         if args and args[0].__class__:
@@ -15,7 +16,14 @@ def api_timing_decorator(f):
         else:
             class_name = None  # 혹은 클래스가 없는 경우에 대한 기본값을 설정합니다.
 
-        print(f'{class_name}.{f.__name__} function took {str((time2 - time1) * 1000.0)} ms')
+        message = f'{class_name}.{f.__name__} function took {str((end_time - start_time) * 1000.0)} ms'
+
+        # 로컬 개발 환경에서는 콘솔에 출력하고, 그 외에는 로그에 기록합니다.
+        if EnvironmentLoader.getenv("MOVIEW_CORE_ENV") == "local":
+            print(message)
+        else:
+            execution_trace_logger.info(elapsed=message)
+
         return ret
 
     return wrap

--- a/moview/utils/timing_decorator.py
+++ b/moview/utils/timing_decorator.py
@@ -1,0 +1,21 @@
+import time
+import inspect
+
+
+# api 호출 시간을 측정하는 데코레이터입니다. 컨트롤러에만 사용바랍니다.
+def api_timing_decorator(f):
+    def wrap(*args, **kwargs):
+        time1 = time.time()
+        ret = f(*args, **kwargs)
+        time2 = time.time()
+
+        # 첫 번째 인수가 self인지 확인하여 메서드 호출 여부를 확인합니다.
+        if args and args[0].__class__:
+            class_name = args[0].__class__.__name__
+        else:
+            class_name = None  # 혹은 클래스가 없는 경우에 대한 기본값을 설정합니다.
+
+        print(f'{class_name}.{f.__name__} function took {str((time2 - time1) * 1000.0)} ms')
+        return ret
+
+    return wrap

--- a/moview/utils/timing_decorator.py
+++ b/moview/utils/timing_decorator.py
@@ -19,7 +19,7 @@ def api_timing_decorator(f):
         message = f'{class_name}.{f.__name__} function took {str((end_time - start_time) * 1000.0)} ms'
 
         # 로컬 개발 환경에서는 콘솔에 출력하고, 그 외에는 로그에 기록합니다.
-        if EnvironmentLoader.getenv("MOVIEW_CORE_ENV") == "local":
+        if EnvironmentLoader.get_local_env("MOVIEW_CORE_ENV") == "local":
             print(message)
         else:
             execution_trace_logger(elapsed=message)

--- a/tests/modules/async/test_async_call.py
+++ b/tests/modules/async/test_async_call.py
@@ -72,18 +72,18 @@ class TestAsyncCall(asynctest.TestCase):
         self.question = "이 회사에서 어떻게 성과를 낼 건지 말씀해주세요."
         self.answer = "탁월한 개발자로서 이 회사의 핵심 인재가 되겠습니다. 그리고 신입 개발자들의 온보딩을 도움으로써 회사의 효율성을 높이는 시니어 개발자가 될 것입니다."
 
-    async def test_async_generate_follow_up(self):
-        start_time = time.perf_counter()
-        total = 100
-        fail = 0
-        result = await give_followup_async_concurrently(self.prompt, self.question, self.answer, total)
-        for i, elem in enumerate(result):
-            is_fail = False
-            print(elem, end="\n")
-            if len(pasre_result(elem)) != 2:
-                fail += 1
-            print(f"{i + 1}번째 시도 {'실패' if is_fail else '성공'}: {result}\n ")
-        print(f"실패 : {fail} 성공률 : {100 - fail / total * 100}%")
-
-        elapsed_time = time.perf_counter() - start_time
-        print(f"elapsed time: {elapsed_time:0.2f} seconds")
+    # async def test_async_generate_follow_up(self):
+    #     start_time = time.perf_counter()
+    #     total = 100
+    #     fail = 0
+    #     result = await give_followup_async_concurrently(self.prompt, self.question, self.answer, total)
+    #     for i, elem in enumerate(result):
+    #         is_fail = False
+    #         print(elem, end="\n")
+    #         if len(pasre_result(elem)) != 2:
+    #             fail += 1
+    #         print(f"{i + 1}번째 시도 {'실패' if is_fail else '성공'}: {result}\n ")
+    #     print(f"실패 : {fail} 성공률 : {100 - fail / total * 100}%")
+    #
+    #     elapsed_time = time.perf_counter() - start_time
+    #     print(f"elapsed time: {elapsed_time:0.2f} seconds")

--- a/tests/modules/light/test_light_question_giver.py
+++ b/tests/modules/light/test_light_question_giver.py
@@ -20,10 +20,13 @@ class TestLightQuestionGiver(unittest.TestCase):
         # given
         job_group = "테스트 직군"
         question_count = 10
+        keyword = "test"
         mock_method.return_value = "light question"
 
         # when
-        result = self.light_question_giver.give_light_questions_by_input_data(job_group, question_count)
+        result = self.light_question_giver.give_light_questions_by_input_data(job_group=job_group,
+                                                                              keyword=keyword,
+                                                                              question_count=question_count)
 
         # then
         self.assertIn("light question", result)

--- a/tests/modules/light/test_light_question_giver.py
+++ b/tests/modules/light/test_light_question_giver.py
@@ -1,0 +1,29 @@
+import unittest
+from unittest.mock import patch
+
+from tests.common_code_for_test import is_not_none_string
+from moview.modules.light.light_question_giver import LightQuestionGiver
+from moview.utils.prompt_loader import PromptLoader
+
+
+class TestLightQuestionGiver(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.prompt_loader = PromptLoader()
+        self.light_question_giver = LightQuestionGiver(self.prompt_loader)
+
+    def test_load_prompt(self):
+        self.assertTrue(is_not_none_string(self.light_question_giver.prompt))
+
+    @patch("moview.modules.light.light_question_giver.LightQuestionGiver.give_light_questions_by_input_data")
+    def test_give_light_question(self, mock_method):
+        # given
+        job_group = "테스트 직군"
+        question_count = 10
+        mock_method.return_value = "light question"
+
+        # when
+        result = self.light_question_giver.give_light_questions_by_input_data(job_group, question_count)
+
+        # then
+        self.assertIn("light question", result)

--- a/tests/repository/test_input_data_repository.py
+++ b/tests/repository/test_input_data_repository.py
@@ -57,7 +57,8 @@ class TestInputDataRepository(unittest.TestCase):
         # given
         test_initial_input_data_model = InitialInputData(
             interviewee_name="test",
-            company_name="test", job_group="test", recruit_announcement=None
+            company_name="test", job_group="test", recruit_announcement=None,
+            keyword="test"
         )
 
         # when
@@ -72,6 +73,7 @@ class TestInputDataRepository(unittest.TestCase):
         self.assertEqual(retrieved_document["company_name"], "test")
         self.assertEqual(retrieved_document["job_group"], "test")
         self.assertEqual(retrieved_document["recruit_announcement"], None)
+        self.assertEqual(retrieved_document["keyword"], "test")
         self.assertEqual(len(retrieved_document["coverletter_id_list"]), 0)
 
     def test_find_input_data_by_object_id(self):

--- a/tests/repository/test_input_data_repository.py
+++ b/tests/repository/test_input_data_repository.py
@@ -42,8 +42,8 @@ class TestInputDataRepository(unittest.TestCase):
         test_document = self.repository.save(test_initial_input_data_model, test_cover_letter_model_list)
 
         # then
-        self.assertNotEqual(test_document.inserted_id, None) # inserted_id는 insert가 성공했을 때, 해당 document의 id를 나타냄.
-        self.assertEqual(test_document.acknowledged, True) # acknowledged는 insert가 성공했는지 여부를 나타냄.
+        self.assertNotEqual(test_document.inserted_id, None)  # inserted_id는 insert가 성공했을 때, 해당 document의 id를 나타냄.
+        self.assertEqual(test_document.acknowledged, True)  # acknowledged는 insert가 성공했는지 여부를 나타냄.
 
         retrieved_document = self.repository.collection.find_one({"_id": test_document.inserted_id})
         self.assertNotEqual(retrieved_document, None)
@@ -53,10 +53,32 @@ class TestInputDataRepository(unittest.TestCase):
         self.assertEqual(retrieved_document["recruit_announcement"], "test")
         self.assertEqual(len(retrieved_document["coverletter_id_list"]), 3)
 
+    def test_save_for_light_mode(self):
+        # given
+        test_initial_input_data_model = InitialInputData(
+            interviewee_name="test",
+            company_name="test", job_group="test", recruit_announcement=None
+        )
+
+        # when
+        test_document = self.repository.save_for_light_mode(test_initial_input_data_model)
+
+        # then
+        self.assertNotEqual(test_document.inserted_id, None)
+        self.assertEqual(test_document.acknowledged, True)
+
+        retrieved_document = self.repository.collection.find_one({"_id": test_document.inserted_id})
+        self.assertNotEqual(retrieved_document, None)
+        self.assertEqual(retrieved_document["company_name"], "test")
+        self.assertEqual(retrieved_document["job_group"], "test")
+        self.assertEqual(retrieved_document["recruit_announcement"], None)
+        self.assertEqual(len(retrieved_document["coverletter_id_list"]), 0)
+
     def test_find_input_data_by_object_id(self):
         # given
         test_initial_input_data_model = InitialInputData(
-            interviewee_name="find_test", company_name="find_test", job_group="find_test", recruit_announcement="find_test"
+            interviewee_name="find_test", company_name="find_test", job_group="find_test",
+            recruit_announcement="find_test"
         )
         test_cover_letter_model_list = [
             CoverLetter(

--- a/tests/service/test_light_mode_service.py
+++ b/tests/service/test_light_mode_service.py
@@ -28,6 +28,7 @@ class TestLightModeService(unittest.TestCase):
             "interviewee_name": "test_user",
             "company_name": "IT회사",
             "job_group": "백엔드",
+            "keyword": "데이터베이스, 네트워크",
             "recruit_announcement": None
         }
 
@@ -45,18 +46,20 @@ class TestLightModeService(unittest.TestCase):
         result = self.light_mode_service.ask_light_question_to_interviewee(
             interviewee_name=self.interviewee_data["interviewee_name"],
             company_name=self.interviewee_data["company_name"],
-            job_group=self.interviewee_data["job_group"]
+            job_group=self.interviewee_data["job_group"],
+            keyword=self.interviewee_data["keyword"]
         )
 
         # then
         self.assertEqual(result, None)
 
-    def test_ask_light_question_to_interviewee(self):
+    def test_ask_light_question_to_interviewee_when_keyword_not_exist(self):
         # when
         result = self.light_mode_service.ask_light_question_to_interviewee(
             interviewee_name=self.interviewee_data["interviewee_name"],
             company_name=self.interviewee_data["company_name"],
-            job_group=self.interviewee_data["job_group"]
+            job_group=self.interviewee_data["job_group"],
+            keyword=None
         )
 
         # then
@@ -67,4 +70,25 @@ class TestLightModeService(unittest.TestCase):
 
         self.assertEqual(len(retrieved_document_list), 6)
 
-        # 10초 정도 소요됨을 확인.
+        # 약 3초 소요
+        print(retrieved_document_list)
+
+    def test_ask_light_question_to_interviewee_when_keyword_exist(self):
+        # when
+        result = self.light_mode_service.ask_light_question_to_interviewee(
+            interviewee_name=self.interviewee_data["interviewee_name"],
+            company_name=self.interviewee_data["company_name"],
+            job_group=self.interviewee_data["job_group"],
+            keyword=self.interviewee_data["keyword"]
+        )
+
+        # then
+        retrieved_document_list = []
+        for question_id, question_content in result["question_document_list"]:
+            retrieved_document = self.question_answer_repository.find_question_by_object_id(str(question_id))
+            retrieved_document_list.append(retrieved_document)
+
+        self.assertEqual(len(retrieved_document_list), 6)
+
+        # 4초 정도 소요됨을 확인.
+        print(retrieved_document_list)

--- a/tests/service/test_light_mode_service.py
+++ b/tests/service/test_light_mode_service.py
@@ -1,0 +1,70 @@
+import unittest
+from unittest.mock import patch
+from moview.repository.input_data.input_data_repository import InputDataRepository
+from moview.repository.question_answer.question_answer_repository import QuestionAnswerRepository
+from moview.config.db.mongo_config import MongoConfig
+from moview.utils.prompt_loader import PromptLoader
+from moview.service.light_mode_service import LightModeService
+from moview.exception.light_question_parse_error import LightQuestionParseError
+from moview.modules.light.light_question_giver import LightQuestionGiver
+
+
+class TestLightModeService(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.mongo_config = (MongoConfig())
+        self.mongo_config.db_name = "test_database"
+        self.prompt_loader = PromptLoader()
+        self.question_answer_repository = QuestionAnswerRepository(mongo_config=self.mongo_config)
+        self.input_data_repository = InputDataRepository(mongo_config=self.mongo_config)
+        self.light_question_giver = LightQuestionGiver(prompt_loader=self.prompt_loader)
+        self.light_mode_service = LightModeService(
+            input_data_repository=self.input_data_repository,
+            question_answer_repository=self.question_answer_repository,
+            light_question_giver=self.light_question_giver
+        )
+
+        self.interviewee_data = {
+            "interviewee_name": "test_user",
+            "company_name": "IT회사",
+            "job_group": "백엔드",
+            "recruit_announcement": None
+        }
+
+    def tearDown(self):
+        # 테스트용 db를 삭제함.
+        self.input_data_repository.client.drop_database("test_database")
+
+    @patch("moview.modules.light.light_question_giver.LightQuestionGiver.give_light_questions_by_input_data")
+    def test_parse_fail_light_question(self, mock_method):
+        # given
+        # 예외 강제 발생
+        mock_method.side_effect = LightQuestionParseError()
+
+        # when
+        result = self.light_mode_service.ask_light_question_to_interviewee(
+            interviewee_name=self.interviewee_data["interviewee_name"],
+            company_name=self.interviewee_data["company_name"],
+            job_group=self.interviewee_data["job_group"]
+        )
+
+        # then
+        self.assertEqual(result, None)
+
+    def test_ask_light_question_to_interviewee(self):
+        # when
+        result = self.light_mode_service.ask_light_question_to_interviewee(
+            interviewee_name=self.interviewee_data["interviewee_name"],
+            company_name=self.interviewee_data["company_name"],
+            job_group=self.interviewee_data["job_group"]
+        )
+
+        # then
+        retrieved_document_list = []
+        for question_id, question_content in result["question_document_list"]:
+            retrieved_document = self.question_answer_repository.find_question_by_object_id(str(question_id))
+            retrieved_document_list.append(retrieved_document)
+
+        self.assertEqual(len(retrieved_document_list), 6)
+
+        # 10초 정도 소요됨을 확인.


### PR DESCRIPTION
### 1. 라이트 모드 만들기
	1-1. 라이트모드는 자소서, 모집 공고 없이 “직무 중심 질문”만 출제한다.
	1-2. 라이트모드는 비동기 처리 필요가 없다.
	1-3. 도메인 모델은 InitialInputData를 재사용 한다. 모집 공고 칼럼만 None 처리하면 끝이였음.
	1-4. 6개 출제하는데 4~6초 정도 소요
	1-5. 파싱 에러일 경우 500 에러 반환
    1-6. 키워드 칼럼 백엔드에 추가(프롬프트에도 반영. LightGiver.json 은 컨플루언스에 업로드 되어 있습니다.)
 
***

### 2. docs 업데이트
	2-1. 테스트 커버리지 업데이트 (67퍼 파일 커버리지, 92퍼 라인 커버리지)
	2-2. 라이트 모드 api 명세서 추가
	2-3. 플라스크 세션 api 명세서 삭제
	2-4. 디렉토리 트리 업데이트
    2-5. 기술 스택 뱃지 추가

***

### 3. Json 업데이트 (라이트 모드 전용 json 추가. 컨플루언스 참고 바람.)
***

### 4. 백엔드 컨트롤러 타이밍 데코레이터 추가 (로컬 환경에선 print(), 그 외엔 로거 활용)
테스트할 때는 콘솔에 출력되는 게 좋음. 그런데 print()보다 console logger를 쓰는 게 더 좋음.
그래서 console logger로 만드려고 했는데, mongo logger랑 겹쳐서 에러남.

결론 : 로컬 테스트 환경에서 console logger 안되고, 다른 일에 비해 크게 중요하지 않아서 print()로 대체함.

***

### 5. 기타
1. db constant 만들어서 리팩토링.
2. user_repository aws 에서 db 에러 발생할 수 있었던 부분 수정.


