### PR TITLE
feat: 컨트롤러 오류 예외처리

### DIFF
--- a/moview/controller/answer_controller.py
+++ b/moview/controller/answer_controller.py
@@ -5,6 +5,7 @@ from http import HTTPStatus
 
 from moview.config.container.container_config import ContainerConfig
 from moview.config.loggers.mongo_logger import *
+from moview.exception.retry_execution_error import RetryExecutionError
 from moview.utils.timing_decorator import api_timing_decorator
 
 api = Namespace('answer', description='answer api')
@@ -26,9 +27,28 @@ class AnswerConstructor(Resource):
 
         answer_service = ContainerConfig().answer_service
 
-        chosen_question, saved_id = answer_service.answer(user_id=user_id, interview_id=interview_id,
-                                                          question_id=question_id, question_content=question_content,
-                                                          answer_content=answer_content)
+        try:
+            chosen_question, saved_id = answer_service.answer(user_id=user_id, interview_id=interview_id,
+                                                              question_id=question_id, question_content=question_content,
+                                                              answer_content=answer_content)
+
+        except RetryExecutionError as e:
+            error_logger(msg="RETRY EXECUTION ERROR", error=e)
+            return make_response(jsonify(
+                {'message': {
+                    'error': '앗! 특이한 질문을 찾아내었습니다. 하지만 제 지식 범위를 넘어선 것 같아요. 다시 시도해주세요.',
+                    'error_message': str(e)
+                }}
+            ), HTTPStatus.INTERNAL_SERVER_ERROR)
+
+        except Exception as e:
+            error_logger(msg="UNKNOWN ERROR", error=e)
+            return make_response(jsonify(
+                {'message': {
+                    'error': '면접관이 혼란스러워하는 것 같아요. 다시 시도해주세요.',
+                    'error_message': str(e)
+                }}
+            ), HTTPStatus.INTERNAL_SERVER_ERROR)
 
         execution_trace_logger("ANSWER CONTROLLER: POST",
                                user_id=user_id,

--- a/moview/controller/answer_controller.py
+++ b/moview/controller/answer_controller.py
@@ -36,7 +36,7 @@ class AnswerConstructor(Resource):
             error_logger(msg="RETRY EXECUTION ERROR", error=e)
             return make_response(jsonify(
                 {'message': {
-                    'error': '앗! 특이한 질문을 찾아내었습니다. 하지만 제 지식 범위를 넘어선 것 같아요. 다시 시도해주세요.',
+                    'error': '오잉? 이상한 오류 메시지가 나타났어요. 다시 시도해주세요.',
                     'error_message': str(e)
                 }}
             ), HTTPStatus.INTERNAL_SERVER_ERROR)

--- a/moview/controller/evaluation_controller.py
+++ b/moview/controller/evaluation_controller.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from flask import make_response, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from flask_restx import Resource, Namespace
@@ -5,6 +7,7 @@ from http import HTTPStatus
 
 from moview.config.container.container_config import ContainerConfig
 from moview.config.loggers.mongo_logger import *
+from moview.exception.retry_execution_error import RetryExecutionError
 from moview.utils.async_controller import async_controller
 from moview.utils.timing_decorator import api_timing_decorator
 
@@ -25,7 +28,35 @@ class EvaluationConstructor(Resource):
 
         evaluation_service = ContainerConfig().evaluation_service
 
-        results = await evaluation_service.evaluate_answers_of_interviewee(user_id=user_id, interview_id=interview_id)
+        try:
+            results = await evaluation_service.evaluate_answers_of_interviewee(user_id=user_id, interview_id=interview_id)
+
+        except asyncio.exceptions.CancelledError as e:
+            error_logger(msg="ASYNCIO CANCELLED ERROR", error=e)
+            return make_response(jsonify(
+                {'message': {
+                    'error': 'Oops! 당신의 평가데이터가 우주로 떠나버렸어! 다시 시도해주세요.',
+                    'error_message': str(e)
+                }}
+            ), HTTPStatus.INTERNAL_SERVER_ERROR)
+
+        except RetryExecutionError as e:
+            error_logger(msg="RETRY EXECUTION ERROR", error=e)
+            return make_response(jsonify(
+                {'message': {
+                    'error': '앗! 우리 서버에 문제가 발생했네요. 다시 시도해주세요.',
+                    'error_message': str(e)
+                }}
+            ), HTTPStatus.INTERNAL_SERVER_ERROR)
+
+        except Exception as e:
+            error_logger(msg="UNKNOWN ERROR", error=e)
+            return make_response(jsonify(
+                {'message': {
+                    'error': '면접관이 혼란스러워하는 것 같아요. 다시 시도해주세요.',
+                    'error_message': str(e)
+                }}
+            ), HTTPStatus.INTERNAL_SERVER_ERROR)
 
         execution_trace_logger("EVALUATION CONTROLLER: POST", user_id=user_id, interview_id=interview_id, results=results)
 

--- a/moview/controller/feedback_controller.py
+++ b/moview/controller/feedback_controller.py
@@ -25,8 +25,18 @@ class FeedbackConstructor(Resource):
 
         feedback_service = ContainerConfig().feedback_service
 
-        feedback_service.feedback(user_id=user_id, interview_id=interview_id, question_ids=question_ids,
-                                  feedback_scores=feedback_scores)
+        try:
+            feedback_service.feedback(user_id=user_id, interview_id=interview_id, question_ids=question_ids,
+                                      feedback_scores=feedback_scores)
+
+        except Exception as e:
+            error_logger(msg="UNKNOWN ERROR", error=e)
+            return make_response(jsonify(
+                {'message': {
+                    'error': '면접관이 혼란스러워하는 것 같아요. 다시 시도해주세요.',
+                    'error_message': str(e)
+                }}
+            ), HTTPStatus.INTERNAL_SERVER_ERROR)
 
         execution_trace_logger("FEEDBACK CONTROLLER: POST",
                                user_id=user_id,

--- a/moview/controller/light_mode_controller.py
+++ b/moview/controller/light_mode_controller.py
@@ -37,8 +37,8 @@ class LightModeConstructor(Resource):
         if result is None:
             return make_response(jsonify(
                 {'message': {
-                    'light_questions': None,
-                    'interview_id': None
+                    'error': 'Oops! 당신의 질문이 우주로 떠나버렸어! 다시 시도해주세요.',
+                    'error_message': 'Parse Error'
                 }}
             ), HTTPStatus.INTERNAL_SERVER_ERROR)
 

--- a/moview/controller/stt_controller.py
+++ b/moview/controller/stt_controller.py
@@ -40,7 +40,8 @@ class STT(Resource):
 
             return make_response(jsonify(
                 {'message': {
-                    'error': str(e)
+                    'error': '음성이 너무 짧거나, 소리가 너무 작아요. 다시 시도해주세요.',
+                    'error_message': str(e)
                 }}
             ), HTTPStatus.BAD_REQUEST)
 
@@ -51,6 +52,7 @@ class STT(Resource):
 
             return make_response(jsonify(
                 {'message': {
-                    'error': "오류가 발생했습니다. 다시 요청해 주세요!"
+                    'error': '면접관이 혼란스러워하는 것 같아요. 다시 시도해주세요.',
+                    'error_message': str(e)
                 }}
             ), HTTPStatus.INTERNAL_SERVER_ERROR)

--- a/moview/controller/tts_controller.py
+++ b/moview/controller/tts_controller.py
@@ -19,7 +19,17 @@ class TTS(Resource):
         request_body = request.get_json()
 
         text = request_body['text']
-        audio_data = TextToSpeech.text_to_base64(text)
+        try:
+            audio_data = TextToSpeech.text_to_base64(text)
+
+        except Exception as e:
+            error_logger(msg="UNKNOWN ERROR", error=e)
+            return make_response(jsonify(
+                {'message': {
+                    'error': '면접관이 혼란스러워하는 것 같아요. 다시 시도해주세요.',
+                    'error_message': str(e)
+                }}
+            ), HTTPStatus.INTERNAL_SERVER_ERROR)
 
         execution_trace_logger("TTS CONTROLLER: POST",
                                text=text,

--- a/moview/modules/input/input_analyzer.py
+++ b/moview/modules/input/input_analyzer.py
@@ -7,6 +7,7 @@ from langchain.prompts.chat import (
 from moview.utils.prompt_loader import PromptLoader
 from moview.environment.llm_factory import LLMModelFactory
 from moview.config.loggers.mongo_logger import prompt_result_logger
+from moview.utils.retry_decorator import async_retry
 from moview.utils.singleton_meta_class import SingletonMeta
 
 
@@ -14,8 +15,9 @@ class InputAnalyzer(metaclass=SingletonMeta):
     def __init__(self, prompt_loader: PromptLoader):
         self.prompt = prompt_loader.load_prompt_json(InputAnalyzer.__name__)
 
+    @async_retry()
     async def analyze_initial_input(self, job_group: str, recruitment_announcement: str, cover_letter_question: str,
-                              cover_letter_answer: str) -> str:
+                                    cover_letter_answer: str) -> str:
         """
         자소서 문항과 자소서 답변을 분석하여 분석 결과를 반환하는 메서드 (답변,문항) 한 개의 쌍에 대해서 분석하는 메서드다.
 

--- a/moview/modules/input/input_analyzer.py
+++ b/moview/modules/input/input_analyzer.py
@@ -40,6 +40,7 @@ class InputAnalyzer(metaclass=SingletonMeta):
                     job posting : {job_posting}
                     cover letter question : {cover_letter_question}
                     cover letter answer : {cover_letter_answer}    
+                    양식을 지켜서 질문을 생성하세요.
                     """)
             ],
             input_variables=["job_posting", "cover_letter_question", "cover_letter_answer"],

--- a/moview/modules/question_generator/followup_question_giver.py
+++ b/moview/modules/question_generator/followup_question_giver.py
@@ -8,6 +8,7 @@ from langchain.prompts.chat import (
 from moview.utils.prompt_loader import PromptLoader
 from moview.environment.llm_factory import LLMModelFactory
 from moview.config.loggers.mongo_logger import prompt_result_logger
+from moview.utils.retry_decorator import retry
 from moview.utils.singleton_meta_class import SingletonMeta
 
 
@@ -16,6 +17,7 @@ class FollowUpQuestionGiver(metaclass=SingletonMeta):
     def __init__(self, prompt_loader: PromptLoader):
         self.prompt = prompt_loader.load_prompt_json(FollowUpQuestionGiver.__name__)
 
+    @retry()
     def give_followup_question(self, question: str, answer: str) -> str:
         """
         꼬리질문을 출제하는 메서드

--- a/moview/service/input_data_service.py
+++ b/moview/service/input_data_service.py
@@ -160,38 +160,30 @@ class InputDataService(metaclass=SingletonMeta):
         # 초기질문 생성
         initial_question_list = []  # List[str]
 
-        try:
-            # 직군 정보만 가지고 초기질문 생성.
-            created_questions = await self.initial_question_giver.give_initial_questions(
-                job_group=job_group,
-                question_count=self.INIT_QUESTION_NUMBER // 2
-            )
-            initial_question_list.extend(created_questions)
+        # 직군 정보만 가지고 초기질문 생성.
+        created_questions = await self.initial_question_giver.give_initial_questions(
+            job_group=job_group,
+            question_count=self.INIT_QUESTION_NUMBER // 2
+        )
+        initial_question_list.extend(created_questions)
 
-            execution_trace_logger("Initial Question By Job", created_questions=created_questions)
+        execution_trace_logger("Initial Question By Job", created_questions=created_questions)
 
-        except InitialQuestionParseError:  # 파싱에 실패한 경우
-            error_logger("Initial Question Parse Error")
+        # coverletter를 하나의 스트링으로 합침.
+        coverletter = ""
+        for question, answer in zip(cover_letter_questions, cover_letter_answers):
+            coverletter += f"Q. {question}\nA. {answer}\n\n"
 
-        try:
-            # coverletter를 하나의 스트링으로 합침.
-            coverletter = ""
-            for question, answer in zip(cover_letter_questions, cover_letter_answers):
-                coverletter += f"Q. {question}\nA. {answer}\n\n"
+        # 자기소개서와 모집공고를 기반으로 초기질문 생성.
+        created_questions = await self.initial_question_giver.give_initial_questions_by_input_data(
+            recruit_announcement=recruit_announcement,
+            coverletter=coverletter,
+            question_count=self.INIT_QUESTION_NUMBER // 2,
+            exclusion_list=initial_question_list  # 이미 생성된 질문은 제외
+        )
+        initial_question_list.extend(created_questions)
 
-            # 자기소개서와 모집공고를 기반으로 초기질문 생성.
-            created_questions = await self.initial_question_giver.give_initial_questions_by_input_data(
-                recruit_announcement=recruit_announcement,
-                coverletter=coverletter,
-                question_count=self.INIT_QUESTION_NUMBER // 2,
-                exclusion_list=initial_question_list  # 이미 생성된 질문은 제외
-            )
-            initial_question_list.extend(created_questions)
-
-            execution_trace_logger("Initial Question By Recruit & Coverletter", created_questions=created_questions)
-
-        except InitialQuestionParseError:  # 파싱에 실패한 경우
-            error_logger("InitialQuestionParseError")
+        execution_trace_logger("Initial Question By Recruit & Coverletter", created_questions=created_questions)
 
         execution_trace_logger("End Initial Question Creation", initial_question_list=initial_question_list)
         return initial_question_list

--- a/moview/service/light_mode_service.py
+++ b/moview/service/light_mode_service.py
@@ -44,7 +44,8 @@ class LightModeService(metaclass=SingletonMeta):
         initial_input_data_model = self.__create_interviewee_data_entity_for_light_mode(
             interviewee_name=interviewee_name,
             company_name=company_name,
-            job_group=job_group)
+            job_group=job_group,
+            keyword=keyword)
 
         # Initial Input Data Document 저장
         initial_input_document = self.input_data_repository.save_for_light_mode(
@@ -86,7 +87,7 @@ class LightModeService(metaclass=SingletonMeta):
 
     @staticmethod
     def __create_interviewee_data_entity_for_light_mode(interviewee_name: str, company_name: str,
-                                                        job_group: str) -> InitialInputData:
+                                                        job_group: str, keyword: str) -> InitialInputData:
         # 도메인 모델 InitialInputData을 재사용한다. 이유는 다음과 같다.
         # 이 모델에 모집공고만 None 처리하면 light mode 용 초기 데이터가 만들어지기 때문.
         # 그리고 CoverLetter 모델 역시 만들 필요가 없어진다.
@@ -94,6 +95,7 @@ class LightModeService(metaclass=SingletonMeta):
             interviewee_name=interviewee_name,
             company_name=company_name,
             job_group=job_group,
+            keyword=keyword,
             recruit_announcement=None)
 
     @staticmethod

--- a/moview/utils/retry_decorator.py
+++ b/moview/utils/retry_decorator.py
@@ -2,7 +2,7 @@ import functools
 import time
 import asyncio
 
-from moview.config.loggers.mongo_logger import execution_trace_logger
+from moview.config.loggers.mongo_logger import error_logger
 from moview.exception.retry_execution_error import RetryExecutionError
 
 
@@ -25,13 +25,13 @@ def retry(max_retries=3, retry_delay=2):
                 try:
                     result = func(*args, **kwargs)
                     return result  # 성공한 경우 결과를 반환합니다.
-                except Exception:
+                except Exception as e:
                     retries += 1
                     if retries < max_retries:
-                        execution_trace_logger(msg=f"{func.__name__} Execution Error: Retry ({retries}/{max_retries})...")
+                        error_logger(msg=f"{func.__name__} Execution Error: Retry ({retries}/{max_retries})...", error=str(e))
                         time.sleep(retry_delay)
                     else:
-                        execution_trace_logger(msg=f"{func.__name__} Execution Error: Failed due to excessive number of retries.")
+                        error_logger(msg=f"{func.__name__} Execution Error: Failed due to excessive number of retries.", error=str(e))
                         raise RetryExecutionError() # 재시도 횟수를 초과하면 예외를 다시 발생시킵니다.
         return wrapper
     return decorator
@@ -56,13 +56,13 @@ def async_retry(max_retries=3, retry_delay=2):
                 try:
                     result = await func(*args, **kwargs)
                     return result  # 성공한 경우 결과를 반환합니다.
-                except Exception:
+                except Exception as e:
                     retries += 1
                     if retries < max_retries:
-                        execution_trace_logger(msg=f"{func.__name__} Execution Error: Retry ({retries}/{max_retries})...")
+                        error_logger(msg=f"{func.__name__} Execution Error: Retry ({retries}/{max_retries})...", error=str(e))
                         await asyncio.sleep(retry_delay)  # 비동기 대기
                     else:
-                        execution_trace_logger(msg=f"{func.__name__} Execution Error: Failed due to excessive number of retries.")
+                        error_logger(msg=f"{func.__name__} Execution Error: Failed due to excessive number of retries.", error=str(e))
                         raise RetryExecutionError() # 재시도 횟수를 초과하면 예외를 다시 발생시킵니다.
         return wrapper
     return decorator


### PR DESCRIPTION
## 컨트롤러 오류 예외처리

1. 모든 컨트롤러에 예외처리를 추가함.
2. 예외처리 response는 아래의 양식을 지키고 있음.
```json
{
    "message": {
        "error": "에러메시지(프론트에 보일 메시지)",
        "error_message": "실제 에러 메시지"
    }
}
```

## Retry 데코레이터 추가

1. InputAnalyzer와 FollowupQuestionGiver에 Retry 데코레이터를 추가함.