### PR TITLE
Fix: Environment Setting

### DIFF
--- a/moview/config/jwt/jwt_config.py
+++ b/moview/config/jwt/jwt_config.py
@@ -1,4 +1,4 @@
-from moview.environment.environment_loader import EnvironmentLoader
+from moview.environment.environment_loader import EnvironmentLoader, EnvironmentEnum
 
 
 class JWTConfig:
@@ -12,7 +12,11 @@ class JWTConfig:
 
     @staticmethod
     def get_jwt_cookie_secure():
-        return False
+        if EnvironmentLoader.get_local_env("MOVIEW_CORE_ENV") in [EnvironmentEnum.PRODUCTION.value,
+                                                                  EnvironmentEnum.DEVELOPMENT.value]:
+            return True
+        else:
+            return False
 
     @staticmethod
     def get_jwt_cookie_csrf_protect():
@@ -20,14 +24,16 @@ class JWTConfig:
 
     @staticmethod
     def get_jwt_cookie_samesite():
-        if EnvironmentLoader.get_local_env("MOVIEW_CORE_ENV") == EnvironmentLoader.EnvironmentEnum.PRODUCTION.value:
+        if EnvironmentLoader.get_local_env("MOVIEW_CORE_ENV") in [EnvironmentEnum.PRODUCTION.value,
+                                                                  EnvironmentEnum.DEVELOPMENT.value]:
             return "None"
         else:
             return None
 
     @staticmethod
     def get_jwt_cookie_domain():
-        if EnvironmentLoader.get_local_env("MOVIEW_CORE_ENV") == EnvironmentLoader.EnvironmentEnum.PRODUCTION.value:
+        if EnvironmentLoader.get_local_env("MOVIEW_CORE_ENV") in [EnvironmentEnum.PRODUCTION.value,
+                                                                  EnvironmentEnum.DEVELOPMENT.value]:
             return ".moview.io"
         else:
             return None

--- a/moview/environment/environment_loader.py
+++ b/moview/environment/environment_loader.py
@@ -15,7 +15,7 @@ class EnvironmentEnum(Enum):
 class EnvironmentLoader(metaclass=SingletonMeta):
     # 주요 환경 변수명 상수 처리
     MOVIEW_CORE_ENV = "MOVIEW_CORE_ENV"
-    MOVIEW_IS_LOCAL = "MOVIEW_IS_LOCAL"
+    MOVIEW_NO_SSM = "MOVIEW_NO_SSM"
     AWS_IAM = "AWS_IAM"
 
     # 개발자별로 다른 값을 사용해야 하는 파라미터인 경우, 아래 리스트에 파라미터 이름을 추가하면 됩니다.
@@ -57,7 +57,7 @@ class EnvironmentLoader(metaclass=SingletonMeta):
 
     @staticmethod
     def getenv(env_name):
-        is_local = EnvironmentLoader.get_local_env(EnvironmentLoader.MOVIEW_IS_LOCAL)
+        is_local = EnvironmentLoader.get_local_env(EnvironmentLoader.MOVIEW_NO_SSM)
         if is_local is not None and is_local.upper() == "TRUE":
             # MOVIEW_IS_LOCAL이 True인 경우 시스템 환경 변수를 사용
             env_value = EnvironmentLoader.get_local_env(env_name.replace("-", "_").upper())

--- a/moview/environment/environment_loader.py
+++ b/moview/environment/environment_loader.py
@@ -9,13 +9,13 @@ from moview.utils.singleton_meta_class import SingletonMeta
 class EnvironmentEnum(Enum):
     LOCAL = "local"
     DEVELOPMENT = "dev"
-    STAGING = "sta"
     PRODUCTION = "prod"
 
 
 class EnvironmentLoader(metaclass=SingletonMeta):
     # 주요 환경 변수명 상수 처리
     MOVIEW_CORE_ENV = "MOVIEW_CORE_ENV"
+    MOVIEW_IS_LOCAL = "MOVIEW_IS_LOCAL"
     AWS_IAM = "AWS_IAM"
 
     # 개발자별로 다른 값을 사용해야 하는 파라미터인 경우, 아래 리스트에 파라미터 이름을 추가하면 됩니다.
@@ -35,7 +35,8 @@ class EnvironmentLoader(metaclass=SingletonMeta):
 
         base_path = f"/moview-core/{environment}"
 
-        if parameter_name in EnvironmentLoader.USER_SPECIFIC_PARAMETERS and environment == EnvironmentEnum.DEVELOPMENT.value:  # 개발자별로 다른 값을 사용해야 하고, 개발 환경이라면
+        # 개발자별로 다른 값을 사용해야 하고, 로컬 환경이라면 AWS IAM을 path에 추가
+        if parameter_name in EnvironmentLoader.USER_SPECIFIC_PARAMETERS and environment == EnvironmentEnum.LOCAL.value:
             return f"{base_path}/{aws_iam}/{parameter_name}"  # AWS IAM을 path에 추가
         else:
             return f"{base_path}/{parameter_name}"
@@ -45,12 +46,24 @@ class EnvironmentLoader(metaclass=SingletonMeta):
         ssm = boto3.client('ssm', region_name='ap-northeast-2')
         parameter_path = EnvironmentLoader.build_ssm_parameter_path(parameter_name)
 
-        response = ssm.get_parameter(Name=parameter_path, WithDecryption=True)
+        try:
+            response = ssm.get_parameter(Name=parameter_path, WithDecryption=True)
+        except Exception as e:
+            raise Exception(f"\n{parameter_path} 환경 변수를 가져오는 중 에러가 발생했습니다.\nERROR:\n{e}")
+
         return response['Parameter']['Value']
+
+
 
     @staticmethod
     def getenv(env_name):
-        if EnvironmentLoader.get_local_env(EnvironmentLoader.MOVIEW_CORE_ENV) == EnvironmentEnum.LOCAL.value:
-            return EnvironmentLoader.get_local_env(env_name.replace("-", "_").upper())  # local은 시스템 환경 변수를 사용
+        is_local = EnvironmentLoader.get_local_env(EnvironmentLoader.MOVIEW_IS_LOCAL)
+        if is_local is not None and is_local.upper() == "TRUE":
+            # MOVIEW_IS_LOCAL이 True인 경우 시스템 환경 변수를 사용
+            env_value = EnvironmentLoader.get_local_env(env_name.replace("-", "_").upper())
+            if env_value is None:
+                raise Exception(f"{env_name} 환경 변수가 Local에서 설정되지 않았습니다.")
+            return env_value
         else:
-            return EnvironmentLoader.get_ssm_parameter(env_name)  # dev, stage, prod는 AWS SSM 파라미터 스토어를 사용
+            # local, dev, prod는 AWS SSM 파라미터 스토어를 사용
+            return EnvironmentLoader.get_ssm_parameter(env_name)


### PR DESCRIPTION
## EnvironmentLoader 수정

1. MOVIEW_CORE_DEV 환경변수는 말그대로 현재 어떤 개발환경인지 나타내는 환경변수로 사용.
2. 컴퓨터의 로컬환경변수를 쓰고 싶은 경우에는 MOVIEW_IS_LOCAL 환경변수를 만들고 "true"로 작성하면 로컬로 분리해서 사용가능.
3. 환경변수를 불러올 때 Error Handling하여 조금 더 상세하게 콘솔에 표기됨.

## JWT Config

1. 기존에는 PRODUCTION 환경에서만 Secure, SameSite, CookieDomain을 설정했는데 DEVELOPMENT 환경도 함께 적용되도록 변경.