### PR TITLE
Refactor/cicd stop application

### DIFF
--- a/scripts/application_start/deploy.sh
+++ b/scripts/application_start/deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source /home/ubuntu/.bashrc
+source /etc/profile.d/codedeploy.sh
 
 REPOSITORY=/home/ubuntu/app
 VENV=$REPOSITORY/venv

--- a/scripts/application_stop/stop_application.sh
+++ b/scripts/application_stop/stop_application.sh
@@ -6,9 +6,17 @@ echo ">>> 애플리케이션 디렉토리로 이동합니다."
 cd $REPOSITORY
 
 echo ">>> Flask 앱이 실행중인지 확인합니다."
-if [ -f gunicorn.pid ]; then
+GUNICORN_PID=$(ps aux | grep 'gunicorn' | grep 'app:app' | awk '{print $2}')
+
+if [ ! -z "$GUNICORN_PID" ]; then
     echo ">>> 작동중인 Flask 앱을 중지합니다."
-    kill -15 $(cat gunicorn.pid)
+    kill -15 $GUNICORN_PID
+    sleep 5  # 프로세스가 종료되기 위한 대기 시간
+
+    if ps -p $GUNICORN_PID > /dev/null; then
+       echo ">>> Gunicorn 프로세스가 아직 종료되지 않았습니다. 강제 종료합니다."
+       kill -9 $GUNICORN_PID
+    fi
 else
     echo ">>> 현재 실행 중인 Flask 앱이 없습니다. 앱 중지를 스킵합니다."
 fi

--- a/scripts/before_install/set_environment_variables_dev.sh
+++ b/scripts/before_install/set_environment_variables_dev.sh
@@ -2,6 +2,27 @@
 
 echo ">>> MOVIEW_CORE_ENV 환경 변수 설정을 확인합니다."
 
+# /etc/profile.d/codedeploy.sh
+ENV_FILE="/etc/profile.d/codedeploy.sh"
+
+echo ">>> MOVIEW_CORE_ENV 환경 변수 설정을 확인합니다."
+
+if grep -q 'export MOVIEW_CORE_ENV=' $ENV_FILE; then
+    if ! grep -q 'export MOVIEW_CORE_ENV="dev"' $ENV_FILE; then
+        sed -i '/export MOVIEW_CORE_ENV=/d' $ENV_FILE
+        echo 'export MOVIEW_CORE_ENV="dev"' >> $ENV_FILE
+        echo ">>> MOVIEW_CORE_ENV 환경 변수가 잘못 설정되어 있었습니다. 'dev'로 재설정하였습니다."
+    else
+        echo ">>> MOVIEW_CORE_ENV 환경 변수가 이미 올바르게 설정되어 있습니다."
+    fi
+else
+    echo 'export MOVIEW_CORE_ENV="dev"' >> $ENV_FILE
+    echo ">>> MOVIEW_CORE_ENV 환경 변수가 설정되지 않았습니다. 'dev'로 설정하였습니다."
+fi
+
+source $ENV_FILE
+
+# .bashrc
 if grep -q 'export MOVIEW_CORE_ENV=' /home/ubuntu/.bashrc; then
     if ! grep -q 'export MOVIEW_CORE_ENV="dev"' /home/ubuntu/.bashrc; then
         sed -i '/export MOVIEW_CORE_ENV=/d' /home/ubuntu/.bashrc

--- a/scripts/before_install/set_environment_variables_dev.sh
+++ b/scripts/before_install/set_environment_variables_dev.sh
@@ -5,27 +5,23 @@ echo ">>> MOVIEW_CORE_ENV 환경 변수 설정을 확인합니다."
 # /etc/profile.d/codedeploy.sh
 ENV_FILE="/etc/profile.d/codedeploy.sh"
 
-echo ">>> MOVIEW_CORE_ENV 환경 변수 설정을 확인합니다."
-
 if [[ ! -f $ENV_FILE ]]; then
-    touch $ENV_FILE
+    sudo touch $ENV_FILE
     echo ">>> $ENV_FILE 파일을 생성하였습니다."
 fi
 
 if grep -q 'export MOVIEW_CORE_ENV=' $ENV_FILE; then
     if ! grep -q 'export MOVIEW_CORE_ENV="dev"' $ENV_FILE; then
-        sed -i '/export MOVIEW_CORE_ENV=/d' $ENV_FILE
-        echo 'export MOVIEW_CORE_ENV="dev"' >> $ENV_FILE
+        sudo sed -i '/export MOVIEW_CORE_ENV=/d' $ENV_FILE
+        echo 'export MOVIEW_CORE_ENV="dev"' | sudo tee -a $ENV_FILE > /dev/null
         echo ">>> MOVIEW_CORE_ENV 환경 변수가 잘못 설정되어 있었습니다. 'dev'로 재설정하였습니다."
     else
         echo ">>> MOVIEW_CORE_ENV 환경 변수가 이미 올바르게 설정되어 있습니다."
     fi
 else
-    echo 'export MOVIEW_CORE_ENV="dev"' >> $ENV_FILE
+    echo 'export MOVIEW_CORE_ENV="dev"' | sudo tee -a $ENV_FILE > /dev/null
     echo ">>> MOVIEW_CORE_ENV 환경 변수가 설정되지 않았습니다. 'dev'로 설정하였습니다."
 fi
-
-source $ENV_FILE
 
 # .bashrc
 if grep -q 'export MOVIEW_CORE_ENV=' /home/ubuntu/.bashrc; then

--- a/scripts/before_install/set_environment_variables_dev.sh
+++ b/scripts/before_install/set_environment_variables_dev.sh
@@ -7,6 +7,11 @@ ENV_FILE="/etc/profile.d/codedeploy.sh"
 
 echo ">>> MOVIEW_CORE_ENV 환경 변수 설정을 확인합니다."
 
+if [[ ! -f $ENV_FILE ]]; then
+    touch $ENV_FILE
+    echo ">>> $ENV_FILE 파일을 생성하였습니다."
+fi
+
 if grep -q 'export MOVIEW_CORE_ENV=' $ENV_FILE; then
     if ! grep -q 'export MOVIEW_CORE_ENV="dev"' $ENV_FILE; then
         sed -i '/export MOVIEW_CORE_ENV=/d' $ENV_FILE

--- a/scripts/before_install/set_environment_variables_main.sh
+++ b/scripts/before_install/set_environment_variables_main.sh
@@ -5,22 +5,23 @@ echo ">>> MOVIEW_CORE_ENV 환경 변수 설정을 확인합니다."
 # /etc/profile.d/codedeploy.sh
 ENV_FILE="/etc/profile.d/codedeploy.sh"
 
-echo ">>> MOVIEW_CORE_ENV 환경 변수 설정을 확인합니다."
+if [[ ! -f $ENV_FILE ]]; then
+    sudo touch $ENV_FILE
+    echo ">>> $ENV_FILE 파일을 생성하였습니다."
+fi
 
 if grep -q 'export MOVIEW_CORE_ENV=' $ENV_FILE; then
     if ! grep -q 'export MOVIEW_CORE_ENV="prod"' $ENV_FILE; then
-        sed -i '/export MOVIEW_CORE_ENV=/d' $ENV_FILE
-        echo 'export MOVIEW_CORE_ENV="prod"' >> $ENV_FILE
+        sudo sed -i '/export MOVIEW_CORE_ENV=/d' $ENV_FILE
+        echo 'export MOVIEW_CORE_ENV="prod"' | sudo tee -a $ENV_FILE > /dev/null
         echo ">>> MOVIEW_CORE_ENV 환경 변수가 잘못 설정되어 있었습니다. 'prod'로 재설정하였습니다."
     else
         echo ">>> MOVIEW_CORE_ENV 환경 변수가 이미 올바르게 설정되어 있습니다."
     fi
 else
-    echo 'export MOVIEW_CORE_ENV="prod"' >> $ENV_FILE
+    echo 'export MOVIEW_CORE_ENV="prod"' | sudo tee -a $ENV_FILE > /dev/null
     echo ">>> MOVIEW_CORE_ENV 환경 변수가 설정되지 않았습니다. 'prod'로 설정하였습니다."
 fi
-
-source $ENV_FILE
 
 # .bashrc
 if grep -q 'export MOVIEW_CORE_ENV=' /home/ubuntu/.bashrc; then

--- a/scripts/before_install/set_environment_variables_main.sh
+++ b/scripts/before_install/set_environment_variables_main.sh
@@ -2,6 +2,27 @@
 
 echo ">>> MOVIEW_CORE_ENV 환경 변수 설정을 확인합니다."
 
+# /etc/profile.d/codedeploy.sh
+ENV_FILE="/etc/profile.d/codedeploy.sh"
+
+echo ">>> MOVIEW_CORE_ENV 환경 변수 설정을 확인합니다."
+
+if grep -q 'export MOVIEW_CORE_ENV=' $ENV_FILE; then
+    if ! grep -q 'export MOVIEW_CORE_ENV="prod"' $ENV_FILE; then
+        sed -i '/export MOVIEW_CORE_ENV=/d' $ENV_FILE
+        echo 'export MOVIEW_CORE_ENV="prod"' >> $ENV_FILE
+        echo ">>> MOVIEW_CORE_ENV 환경 변수가 잘못 설정되어 있었습니다. 'prod'로 재설정하였습니다."
+    else
+        echo ">>> MOVIEW_CORE_ENV 환경 변수가 이미 올바르게 설정되어 있습니다."
+    fi
+else
+    echo 'export MOVIEW_CORE_ENV="prod"' >> $ENV_FILE
+    echo ">>> MOVIEW_CORE_ENV 환경 변수가 설정되지 않았습니다. 'prod'로 설정하였습니다."
+fi
+
+source $ENV_FILE
+
+# .bashrc
 if grep -q 'export MOVIEW_CORE_ENV=' /home/ubuntu/.bashrc; then
     if ! grep -q 'export MOVIEW_CORE_ENV="prod"' /home/ubuntu/.bashrc; then
         sed -i '/export MOVIEW_CORE_ENV=/d' /home/ubuntu/.bashrc


### PR DESCRIPTION
배포가 다시 진행되어도 정상적으로 애플리케이션이 작동되도록 수정했습니다.

## 애플리케이션 종료 로직 개선
- 기존에 gunicorn.pid를 이용하던 로직 대신, 직접 프로세스를 확인하고 종료하는 로직으로 변경
- 종료 되기 전에 배포가 다시 시작되는 문제를 대비하여 종료 요청 후 5초 대기를 하고, 그래도 종료 되지 않았다면 강제로 종료
- gunicorn.pid의 내용이 잘못 되었을 경우에도 대처 가능

## 환경 변수를 불러올 수 있도록 개선
- CodeDeploy는 .bashrc의 환경 변수를 불러오지 못함 #127 
- 환경을 초기화하거나 환경 변수 등을 저장하는 쉘 스크립트가 있는 /etc/profile.d에 codedeploy.sh를 생성하여 환경 변수를 저장
- 이후 deploy.sh에서 이 쉘 스크립트를 실행하여 환경 변수를 불러올 수 있게 됨