### PR TITLE
Refactor: Initial Question Prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,26 +14,26 @@
 
 ***
 
-### API 명세서 (인증 / 인가 관련 명세서는 미포함)
+### API 명세서
 
 ***
 
 #### /interview/input
 
 ```
-method : POST
-request: json(면접자 이름, 회사, 직군, 모집공고, 자소서 문항, 자소서 답변)
-response: json(초기 질문 n개에 대한 데이터{"objectId":id, ""}, 인터뷰 아이디)
-description: 초기 질문 받아오는 API
-GPT call: O
+Method        : POST
+Request       : json(이름, 회사, 직군, 모집공고, 자소서 문항, 자소서 답변)
+Response      : json(초기 질문 리스트, 인터뷰 아이디)
+Description   : 초기 질문 받아오는 API
 ```
 
-request json
+Request JSON
 
 ```json
 {
-  "interviewee_name": "아무개",
-  "company_name": "아무개 회사",
+  "interviewee_name": "홍길동",
+  "company_name": "지원 회사 이름",
+  "job_group": "지원 직군",
   "recruit_announcement": "모집 공고",
   "cover_letter_questions": [
     "자소서 문항 1",
@@ -47,7 +47,7 @@ request json
 
 ```
 
-response json
+Response JSON
 
 ```json
 {
@@ -61,10 +61,7 @@ response json
         "question_id": "초기 질문 id",
         "content": "GPT 결과"
       },
-      {
-        "question_id": "초기 질문 id",
-        "content": "GPT 결과"
-      }
+      ...
     ],
     "interview_id": "인터뷰 id"
   }
@@ -76,26 +73,25 @@ response json
 #### /interview/light
 
 ```
-method : POST
-request: json(면접자 이름, 회사, 직군, 직무면접 키워드)
-response: json(초기 질문 n개에 대한 데이터{"objectId":id, ""}, 인터뷰 아이디)
-description: 초기 질문 받아오는 API (light mode)
-GPT call: O
+Method        : POST
+Request       : json(이름, 회사, 직군, 직무면접 키워드)
+Response      : json(초기 질문 리스트, 인터뷰 아이디)
+Description   : 초기 질문 받아오는 API (light mode)
 ```
 
-request json
+Request JSON
 
 ```json
 {
-    "interviewee_name":"tester",
-    "company_name":"Facebook",
-    "job_group":"Backend",
-    "keyword":"아파치 카프카"
+    "interviewee_name":"홍길동",
+    "company_name":"지원 회사 이름",
+    "job_group":"지원 직군",
+    "keyword":"면접 키워드, ..."
 }
 
 ```
 
-response json
+Response JSON
 
 ```json
 {
@@ -109,10 +105,7 @@ response json
         "question_id": "초기 질문 id",
         "content": "GPT 결과"
       },
-      {
-        "question_id": "초기 질문 id",
-        "content": "GPT 결과"
-      }
+      ...
     ],
     "interview_id": "인터뷰 id"
   }
@@ -124,31 +117,31 @@ response json
 #### /interview/answer
 
 ```
-method : POST
-request:cookie(세션id),json(인터뷰 id, 질문 id, 질문 내용, 사용자 답변)
-response: json(출제할 질문, 출제 질문 id) 
-description: 
-GPT call: O (동기 처리)
+Method        : POST
+Request       : json(인터뷰 id, 질문 id, 질문 내용, 사용자 답변)
+Response      : json(꼬리 질문, 출제 질문 id)
+Description   : 꼬리질문을 생성하는 API
 ```
 
-request json
+Request JSON
 
 ```json
 {
-  "user_id": "session_id일수도 있음 ",
-  "interview_id": "interview_id",
+  "interview_id": "인터뷰 id",
   "question_id": "최근에 출제했던 질문 id",
   "question_content": "최근에 출제했던 질문 내용",
   "answer_content": "사용자 답변"
 }
 ```
 
-response json
+Response JSON
 
 ```json
 {
-  "question_content": "꼬리질문 내용 (Nullable)",
-  "question_id": "꼬리 질문 id (Nullable)"
+  "message": {
+    "question_content": "꼬리질문 내용 (Nullable)",
+    "question_id": "꼬리 질문 id (Nullable)"
+  }
 }
 ```
 
@@ -157,61 +150,119 @@ response json
 #### /interview/evaluation
 
 ```
-method : POST
-request: cookie(세션id), json(user_id, interview_id)
-response: json(질문 내용, 답변 내용, 평가 내용)
-description: 사용자가 답변했던 내용에 대한 평가 내역을 불러오는 api
-GPT call: O
+Method        : POST
+Request       : json(인터뷰 id)
+Response      : json(질문 id, 질문 내용, 답변 내용, 평가 내용)
+Description   : 사용자가 답변했던 내용에 대한 평가를 생성하고 반환하는 API
 ```
 
-response json
+Request JSON
 ```json
 {
-  "evaluations": [
-    {
-      "question_id": "질문 id. Question 엔티티의 _id.",
-      "question": "질문 내용. Question 엔티티 content 칼럼.",
-      "answer": "답변 내용. Answer 엔티티 content 칼럼.",
-      "evaluation": "평가 내용. Answer 엔티티 칼럼."
-    },
-    {
-      "question_id": "질문 id. Question 엔티티의 _id.",
-      "question": "질문 내용. Question 엔티티 content 칼럼.",
-      "answer": "답변 내용. Answer 엔티티 content 칼럼.",
-      "evaluation": "평가 내용. Answer 엔티티 칼럼."
-    }
-  ]
+  "interview_id": "인터뷰 id"
+}
+```
+
+Response JSON
+```json
+{
+  "message": {
+    "evaluations": [
+      {
+          "question_id": "질문 id",
+          "question": "질문 내용",
+          "answer": "답변 내용",
+          "evaluation": "평가 내용"
+      },
+      ...
+    ]
+  }
 }
 ```
 
 ***
 
-#### /interview/feedback
+#### /interview/tts
 
 ```
-method : POST
-request: cookie(세션id), json(각 답변분석에 대한 유저의 평가)
-response: X
-description: 유저의 서비스평가를 받고, 종료 
-GPT call: X (동기 처리)
+Method        : POST
+Request       : json(인터뷰 id, 내용)
+Response      : json(TTS 음성 내용 - base64)
+Description   : Text를 음성파일로 변환하는 API
 ```
 
-request json
-
+Request JSON
 ```json
 {
-  "user_id": "session_id일수도 있음 ",
-  "interview_id": "interview_id",
-  "question_ids": [
-    "질문 id 1",
-    "질문 id 2"
-  ],
-  "feedback_scores": [
-    "질문 id 1에 대한 피드백 점수",
-    "질문 id 2에 대한 피드백 점수"
-  ]
+  "interview_id": "인터뷰 id",
+  "text": "TTS로 변환할 내용"
 }
 ```
+
+Response JSON
+```json
+{
+  "message": {
+    "audio_data": "TTS 음성 내용 - base64"
+  }
+}
+```
+
+***
+
+#### /interview/stt
+
+```
+Method        : POST
+Request       : json(인터뷰 id, 오디오 데이터)
+Response      : json(음성을 텍스트로 변환한 내용)
+Description   : 음성파일을 Text로 변환하는 API
+```
+
+Request JSON
+```json
+{
+  "interview_id": "인터뷰 id",
+  "audio_data": "음성을 텍스트로 변환한 내용"
+}
+```
+
+Response JSON
+```json
+{
+  "message": {
+    "text": "음성을 텍스트로 변환한 내용"
+  }
+}
+```
+
+***
+
+#### /slack/feedback
+
+```
+Method        : POST
+Request       : json(이름, 피드백 내용, 생성 시간)
+Response      : json(성공적으로 전달했음을 알리는 메시지)
+Description   : 사용자의 피드백 내용을 개발자 Slack의 Feedback 채널로 보내주는 API
+```
+
+Request JSON
+```json
+{
+  "profile_nickname": "홍길동",
+  "user_message": "피드백 내용",
+  "created_at": "생성 시간"
+}
+```
+
+Response JSON
+```json
+{
+  "message": "OK"
+}
+```
+
 
 ***
 

--- a/app.py
+++ b/app.py
@@ -36,10 +36,12 @@ def set_moview_config():
     Flask App에 API 추가
     """
     app.secret_key = ''.join(random.choice(string.ascii_letters) for i in range(20))
-    api = Api(app)
+    api = Api(app, version='3.2', title='Moview API', description='Moview API', doc='/docs')
 
     app.config['JSON_AS_ASCII'] = False  # 한글 깨짐 방지
 
+    # health check api
+    api.add_namespace(health_controller.api, '/')
     api.add_namespace(input_data_controller.api, '/interview')
     api.add_namespace(answer_controller.api, '/interview')
     api.add_namespace(evaluation_controller.api, '/interview')
@@ -56,8 +58,6 @@ def set_moview_config():
     # slack api
     api.add_namespace(slack_controller.api, '/slack')
 
-    # health check api
-    api.add_namespace(health_controller.api, '/')
 
 
 def set_jwt_config():

--- a/moview/controller/health_controller.py
+++ b/moview/controller/health_controller.py
@@ -6,7 +6,7 @@ from http import HTTPStatus
 api = Namespace('health', description='health api')
 
 
-@api.route('/health')
+@api.route('health')
 class HealthChecker(Resource):
 
     def get(self):

--- a/moview/modules/input/initial_question_giver.py
+++ b/moview/modules/input/initial_question_giver.py
@@ -17,10 +17,11 @@ class InitialQuestionGiver(metaclass=SingletonMeta):
 
     @async_retry()
     async def give_initial_questions_by_input_data(
-            self, recruit_announcement: str, cover_letter: str, question_count: int, exclusion_list: List[str] = None
+            self, company_name, recruit_announcement: str, cover_letter: str, question_count: int, exclusion_list: List[str] = None
     ) -> List[str]:
         """
         Args:
+            company_name: 회사 이름
             recruit_announcement: 모집공고
             cover_letter: 자기소개서
             question_count: 출제할 질문 개수
@@ -34,6 +35,7 @@ class InitialQuestionGiver(metaclass=SingletonMeta):
         messages = [{
             "role": "system",
             "content": self.prompt["create_question_by_input_data"].format(
+                company_name=company_name,
                 exclusion_question=exclusion_question,
                 question_count=question_count)
         }, {
@@ -55,10 +57,12 @@ class InitialQuestionGiver(metaclass=SingletonMeta):
             raise InitialQuestionParseError()  # 파싱이 실패하면, InitialQuestionParseError를 발생시킵니다.
 
     @async_retry()
-    async def give_initial_questions(self, job_group: str, question_count: int, exclusion_list: List[str] = None) -> \
-            List[str]:
+    async def give_initial_questions(
+            self, company_name:str, job_group: str, question_count: int, exclusion_list: List[str] = None
+    ) -> List[str]:
         """
         Args:
+            company_name: 회사 이름
             job_group: 타겟 직군
             question_count: 출제할 질문 개수
             exclusion_list: 제외할 질문 리스트
@@ -71,6 +75,7 @@ class InitialQuestionGiver(metaclass=SingletonMeta):
         messages = [{
             "role": "system",
             "content": self.prompt["create_question"].format(
+                company_name=company_name,
                 exclusion_question=exclusion_question,
                 job_group=job_group,
                 question_count=question_count)

--- a/moview/service/answer/answer_service.py
+++ b/moview/service/answer/answer_service.py
@@ -55,7 +55,8 @@ class AnswerService(metaclass=SingletonMeta):
                 saved_followup_question_id = self.__save_followup_question(interview_id=interview_id,
                                                                            question_id=question_id,
                                                                            followup_question_content=chosen_question)
-                return chosen_question, str(saved_followup_question_id)
+                return None, None
+                # return chosen_question, str(saved_followup_question_id)
 
             else:
                 execution_trace_logger(msg="NO_FOLLOWUP_QUESTION")

--- a/moview/service/answer/answer_service.py
+++ b/moview/service/answer/answer_service.py
@@ -55,8 +55,8 @@ class AnswerService(metaclass=SingletonMeta):
                 saved_followup_question_id = self.__save_followup_question(interview_id=interview_id,
                                                                            question_id=question_id,
                                                                            followup_question_content=chosen_question)
-                return None, None
-                # return chosen_question, str(saved_followup_question_id)
+
+                return chosen_question, str(saved_followup_question_id)
 
             else:
                 execution_trace_logger(msg="NO_FOLLOWUP_QUESTION")

--- a/moview/service/input_data_service.py
+++ b/moview/service/input_data_service.py
@@ -90,6 +90,7 @@ class InputDataService(metaclass=SingletonMeta):
         # Initial Question Entity Model 생성 및 Document 저장
         question_document_id_list = []
 
+        initial_question_list = ["TEST1", "TEST2", "TEST3"] # 시연용 질문 리스트
         for question_content in initial_question_list:
             question_model = self.__create_question_entity(question_content=question_content)
             question_document = self.question_answer_repository.save_question(question_model)

--- a/moview/service/input_data_service.py
+++ b/moview/service/input_data_service.py
@@ -172,13 +172,13 @@ class InputDataService(metaclass=SingletonMeta):
         initial_question_list = []  # List[str]
 
         # 직군 정보만 가지고 초기질문 생성.
-        created_questions = await self.initial_question_giver.give_initial_questions(
-            job_group=job_group,
-            question_count=self.INIT_QUESTION_NUMBER // 2
-        )
-        initial_question_list.extend(created_questions)
-
-        execution_trace_logger("Initial Question By Job", created_questions=created_questions)
+        # created_questions = await self.initial_question_giver.give_initial_questions(
+        #     job_group=job_group,
+        #     question_count=self.INIT_QUESTION_NUMBER // 2
+        # )
+        # initial_question_list.extend(created_questions)
+        #
+        # execution_trace_logger("Initial Question By Job", created_questions=created_questions)
 
         # cover_letter를 하나의 스트링으로 합침.
         cover_letter = ""
@@ -189,7 +189,7 @@ class InputDataService(metaclass=SingletonMeta):
         created_questions = await self.initial_question_giver.give_initial_questions_by_input_data(
             recruit_announcement=recruit_announcement,
             cover_letter=cover_letter,
-            question_count=self.INIT_QUESTION_NUMBER // 2,
+            question_count=self.INIT_QUESTION_NUMBER,
             exclusion_list=initial_question_list  # 이미 생성된 질문은 제외
         )
         initial_question_list.extend(created_questions)

--- a/moview/service/input_data_service.py
+++ b/moview/service/input_data_service.py
@@ -52,21 +52,23 @@ class InputDataService(metaclass=SingletonMeta):
         }
         """
         # 사용자 입력 정보 분석
-        task1 = asyncio.create_task(self.__analyze_initial_inputs_of_interviewee(
+        analyze_initial_input_task = asyncio.create_task(self.__analyze_initial_inputs_of_interviewee(
             job_group=job_group,
             recruit_announcement=recruit_announcement,
             cover_letter_questions=cover_letter_questions,
             cover_letter_answers=cover_letter_answers
         ))
         # 초기 질문 생성
-        task2 = asyncio.create_task(self.__create_initial_question_list(
+        create_initial_question_task = asyncio.create_task(self.__create_initial_question_list(
             job_group=job_group,
             recruit_announcement=recruit_announcement,
             cover_letter_questions=cover_letter_questions,
             cover_letter_answers=cover_letter_answers
         ))
         # 비동기로 병렬처리함
-        analyzed_initial_inputs_of_interviewee, initial_question_list = await asyncio.gather(task1, task2)
+        analyzed_initial_inputs_of_interviewee, initial_question_list = await asyncio.gather(
+            analyze_initial_input_task, create_initial_question_task
+        )
 
         # Initial Input Data Entity Model 생성
         initial_input_data_model, cover_letter_model_list = self.__create_interviewee_data_entity(
@@ -110,12 +112,15 @@ class InputDataService(metaclass=SingletonMeta):
             cover_letter_answers: List[str]
     ) -> List[str]:
         """
-        (자소서 문항,자소서 답변) 전체 쌍에 대해 LLM을 이용하여 분석하는 메서드
-        해당 쌍을 4개 입력 받았다면, 4개의 쌍에 대해 분석을 수행한다.
-        cover_letter_questions 와 cover_letter_answers 의 길이는 같아야 한다.
-        그리고 인덱스를 i라 할 때, (cover_letter_questions[i], cover_letter_answers[i]) 쌍이다.
+        면접자의 자기소개서를 평가하는 메소드
+        Args:
+            job_group: 면접자 직군
+            recruit_announcement: 면접자 목표회사 모집공고
+            cover_letter_questions: 면접자 자소서 문항 리스트
+            cover_letter_answers: 면접자 자소서 답변 리스트
 
-        Returns: 입력 파라미터에 대한 분석 결과 문자열 리스트 (올바르지 않은 입력은 공백으로 치환)
+        Returns:
+            LLM을 이용하여 평가한 내용을 저장한 리스트
         """
         if len(cover_letter_questions) != len(cover_letter_answers):
             error_logger("자소서 문항과 자소서 답변의 개수가 일치하지 않습니다.",
@@ -126,15 +131,17 @@ class InputDataService(metaclass=SingletonMeta):
         analysis_count = len(cover_letter_questions)
 
         # 자소서 개수만큼 분석 시작.
-        tasks = []
+        analyzer_task_list = []
         for i in range(analysis_count):
-            tasks.append(asyncio.create_task(self.initial_input_analyzer.analyze_initial_input(
+            analyzer_task = asyncio.create_task(self.initial_input_analyzer.analyze_initial_input(
                 job_group=job_group,
                 recruitment_announcement=recruit_announcement,
                 cover_letter_question=cover_letter_questions[i],
                 cover_letter_answer=cover_letter_answers[i]
-            )))
-        analysis_list = await asyncio.gather(*tasks)
+            ))
+            analyzer_task_list.append(analyzer_task)
+
+        analysis_list = await asyncio.gather(*analyzer_task_list)
 
         execution_trace_logger(
             "Analyzed Input Data",
@@ -151,11 +158,15 @@ class InputDataService(metaclass=SingletonMeta):
             cover_letter_answers: List[str]
     ) -> List[str]:
         """
+        면접자의 자기소개서와 채용공고를 기반으로 초기질문을 생성하는 메소드
         Args:
-            job_group: 타겟 직군
-            recruit_announcement: 모집공고
-            cover_letter_questions: 자기소개서 문항 리스트
-            cover_letter_answers: 자기소개서 답변 리스트
+            job_group: 면접자 직군
+            recruit_announcement: 면접자 목표회사 모집공고
+            cover_letter_questions: 면접자 자소서 문항 리스트
+            cover_letter_answers: 면접자 자소서 답변 리스트
+
+        Returns:
+            생성된 초기질문 리스트
         """
         # 초기질문 생성
         initial_question_list = []  # List[str]

--- a/moview/service/input_data_service.py
+++ b/moview/service/input_data_service.py
@@ -90,7 +90,6 @@ class InputDataService(metaclass=SingletonMeta):
         # Initial Question Entity Model 생성 및 Document 저장
         question_document_id_list = []
 
-        initial_question_list = ["TEST1", "TEST2", "TEST3"] # 시연용 질문 리스트
         for question_content in initial_question_list:
             question_model = self.__create_question_entity(question_content=question_content)
             question_document = self.question_answer_repository.save_question(question_model)

--- a/moview/service/input_data_service.py
+++ b/moview/service/input_data_service.py
@@ -60,6 +60,7 @@ class InputDataService(metaclass=SingletonMeta):
         ))
         # 초기 질문 생성
         create_initial_question_task = asyncio.create_task(self.__create_initial_question_list(
+            company_name=company_name,
             job_group=job_group,
             recruit_announcement=recruit_announcement,
             cover_letter_questions=cover_letter_questions,
@@ -152,6 +153,7 @@ class InputDataService(metaclass=SingletonMeta):
 
     async def __create_initial_question_list(
             self,
+            company_name: str,
             job_group: str,
             recruit_announcement: str,
             cover_letter_questions: List[str],
@@ -173,6 +175,7 @@ class InputDataService(metaclass=SingletonMeta):
 
         # 직군 정보만 가지고 초기질문 생성.
         # created_questions = await self.initial_question_giver.give_initial_questions(
+        #     company_name=company_name,
         #     job_group=job_group,
         #     question_count=self.INIT_QUESTION_NUMBER // 2
         # )
@@ -187,6 +190,7 @@ class InputDataService(metaclass=SingletonMeta):
 
         # 자기소개서와 모집공고를 기반으로 초기질문 생성.
         created_questions = await self.initial_question_giver.give_initial_questions_by_input_data(
+            company_name=company_name,
             recruit_announcement=recruit_announcement,
             cover_letter=cover_letter,
             question_count=self.INIT_QUESTION_NUMBER,

--- a/tests/modules/input/test_inital_question_giver.py
+++ b/tests/modules/input/test_inital_question_giver.py
@@ -13,9 +13,10 @@ class TestInitialQuestionGiver(asynctest.TestCase):
 
     def test_load_prompt(self):
         self.assertTrue(is_not_none_string(self.giver.prompt["create_question"]))
-        print(self.giver.prompt["create_question"].format(exclusion_question="", job_group="백엔드 개발자", question_count=2))
+        print(self.giver.prompt["create_question"].format(exclusion_question="", company_name="삼성 SDS", job_group="백엔드 개발자", question_count=2))
 
     async def test_give_initial_questions_by_input_data(self):
+        company_name = "삼성 청년 SW 아카데미"
         recruit_announcement = ("삼성 청년 SW 아카데미\n8기 모집 Coming soon\n청년 SW인재 양성을 위한 SSAFY 8기 모집이 곧 시작됩니다.\n궁금한 SSAFY 8기 "
                                 "모집! 미리 알려드립니다!\n\n8기 모집 안내\n지원 자격\n만 29세 이하(92.7.1이후 출생자), 미취업자,\n국내외 4년제 대학 졸업자 및 "
                                 "졸업예정자(전공무관)\n\n교육 기간\n2022년 7월 ~ 2023년 6월(1년)\n\n교육 장소\n서울, 대전, 구미, 광주, "
@@ -32,6 +33,7 @@ class TestInitialQuestionGiver(asynctest.TestCase):
         question_count = 3
 
         initial_questions = await self.giver.give_initial_questions_by_input_data(
+            company_name=company_name,
             recruit_announcement=recruit_announcement,
             cover_letter=cover_letter,
             question_count=question_count
@@ -40,15 +42,20 @@ class TestInitialQuestionGiver(asynctest.TestCase):
         self.assertTrue(len(initial_questions) == question_count)
 
     async def test_give_initial_questions(self):
+        company_name = "삼성 SDS"
         job_group = "백엔드 개발자"
         question_count = 3
 
-        initial_questions = await self.giver.give_initial_questions(job_group=job_group,
-                                                                    question_count=question_count)
+        initial_questions = await self.giver.give_initial_questions(
+            company_name=company_name,
+            job_group=job_group,
+            question_count=question_count
+        )
         print(initial_questions)
         self.assertTrue(len(initial_questions) == question_count)
 
     async def test_give_initial_questions_with_exclusion_list(self):
+        company_name = "삼성 SDS"
         job_group = "백엔드 개발자"
         question_count = 3
         exclusion_list = [
@@ -56,8 +63,11 @@ class TestInitialQuestionGiver(asynctest.TestCase):
             "이전에 개발한 백엔드 시스템에서 겪은 가장 큰 어려움은 무엇이었나요?"
         ]
 
-        initial_questions = await self.giver.give_initial_questions(job_group=job_group,
-                                                                    question_count=question_count,
-                                                                    exclusion_list=exclusion_list)
+        initial_questions = await self.giver.give_initial_questions(
+            company_name=company_name,
+            job_group=job_group,
+            question_count=question_count,
+            exclusion_list=exclusion_list
+        )
         print(initial_questions)
         self.assertLessEqual(len(initial_questions), question_count)


### PR DESCRIPTION
## 초기 질문 생성 프롬프트 변경

1. 프롬프트에 지원하는 회사 정보를 넣음.
2. 이전에 질문을 생성할 때 직군정보만 가지고 3개, 자소서 기반 3개를 생성했었음.
3. 직군 정보 기반 질문 생성은 퀄리티가 안좋아서 6개 모두 자소서 기반으로 생성하도록 변경함.

## API 명세서 업데이트

1. README.md의 API 명세서를 최신버전에 맞게 업데이트함.

## Health Route 수정

1. 서버 상태를 체크하기 위한 Health API의 경로가 `//health`로 잘못 설정되어 있어서 `/health`로 수정함.

---
> **브랜치는 삭제하지 말아주세요.**
해당 PR이 main까지 배포되면, 다시 시연용으로 dev에 한번 더 배포할 예정입니다.
그리고 main까지 배포하게 되면, 파라미터 스토어에서 배포용 InitialQuestionGiver 프롬프트의 내용을 갱신해야함.